### PR TITLE
Avoid disabling 'jest/no-try-expect'

### DIFF
--- a/packages/delivery-expo/test/queue.test.js
+++ b/packages/delivery-expo/test/queue.test.js
@@ -203,7 +203,7 @@ describe('delivery: expo -> queue', () => {
       done()
     })
 
-    it('should rethrow errors when the directory was not succesfully created', async (done) => {
+    it('should rethrow errors when the directory was not succesfully created', async () => {
       const exists = false
       const isDirectory = false
       FileSystem.getInfoAsync = async () => ({ exists, isDirectory })
@@ -214,18 +214,8 @@ describe('delivery: expo -> queue', () => {
       })
 
       const q = new Queue('stuff')
-      let didErr = false
-      try {
-        await q.init()
-      } catch (e) {
-        // eslint-disable-next-line jest/no-try-expect
-        expect(e).toBeTruthy()
-        // eslint-disable-next-line jest/no-try-expect
-        expect(e.message).toBe('fleerp')
-        didErr = true
-      }
-      expect(didErr).toBe(true)
-      done()
+
+      await expect(q.init()).rejects.toThrow('fleerp')
     })
 
     it('should reject all pending promises', async (done) => {

--- a/packages/expo-cli/lib/test/add-hook.test.js
+++ b/packages/expo-cli/lib/test/add-hook.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-try-expect */
 const withFixture = require('./lib/with-fixture')
 const addHook = require('../add-hook')
 const { readFile } = require('fs/promises')
@@ -30,32 +29,17 @@ describe('expo-cli: add-hook', () => {
 
   it('should provide a reasonable error when there is no app.json', async () => {
     await withFixture('empty-00', async (projectRoot) => {
-      try {
-        await addHook(projectRoot)
-        expect('should not be here').toBe(false)
-      } catch (e) {
-        expect(e.message).toMatch(/^Couldn’t find app\.json in/)
-      }
+      await expect(addHook(projectRoot)).rejects.toThrow(/^Couldn’t find app\.json in/)
     })
   })
 
   it('should provide a reasonable error when app.json is not valid JSON', async () => {
     await withFixture('malformed-json-00', async (projectRoot) => {
-      try {
-        await addHook(projectRoot)
-        expect('should not be here').toBe(false)
-      } catch (e) {
-        expect(e.message).toMatch(/it wasn’t valid JSON/)
-      }
+      await expect(addHook(projectRoot)).rejects.toThrow(/it wasn’t valid JSON/)
     })
   })
 
   it('doesn’t swallow any other errors', async () => {
-    try {
-      await addHook(/* projectRoot is required */)
-      expect('should not be here').toBe(false)
-    } catch (e) {
-      expect(e.message).toMatch(/The "path" argument must be of type string/)
-    }
+    await expect(addHook()).rejects.toThrow(/The "path" argument must be of type string/)
   })
 })

--- a/packages/expo-cli/lib/test/install.test.js
+++ b/packages/expo-cli/lib/test/install.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-try-expect */
 const withFixture = require('./lib/with-fixture')
 const { EventEmitter } = require('events')
 const { Readable } = require('stream')
@@ -99,14 +98,14 @@ describe('expo-cli: install', () => {
     const install = require('../install')
 
     await withFixture('blank-00', async (projectRoot) => {
-      try {
-        await install('yarn', 'latest', projectRoot)
-        expect('should not be here').toBe(false)
-      } catch (e) {
-        expect(e.message).toMatch(/Command exited with non-zero exit code/)
-        expect(e.message).toMatch(/some data on stdout/)
-        expect(e.message).toMatch(/some data on stderr/)
-      }
+      const expected = `Command exited with non-zero exit code (1) "yarn add @bugsnag/expo@latest"
+stdout:
+some data on stdout
+
+stderr:
+some data on stderr`
+
+      await expect(install('yarn', 'latest', projectRoot)).rejects.toThrow(expected)
     })
   })
 
@@ -135,12 +134,7 @@ describe('expo-cli: install', () => {
     const install = require('../install')
 
     await withFixture('blank-00', async (projectRoot) => {
-      try {
-        await install('yarn', 'latest', projectRoot)
-        expect('should not be here').toBe(false)
-      } catch (e) {
-        expect(e.message).toMatch(/floop/)
-      }
+      await expect(install('yarn', 'latest', projectRoot)).rejects.toThrow(/floop/)
     })
   })
 
@@ -151,12 +145,7 @@ describe('expo-cli: install', () => {
     const install = require('../install')
 
     await withFixture('blank-00', async (projectRoot) => {
-      try {
-        await install(undefined, 'latest', projectRoot)
-        expect('should not be here').toBe(false)
-      } catch (e) {
-        expect(e.message).toMatch(/Don’t know what command to use for /)
-      }
+      await expect(install(undefined, 'latest', projectRoot)).rejects.toThrow(/Don’t know what command to use for /)
     })
   })
 })

--- a/packages/expo-cli/lib/test/set-api-key.test.js
+++ b/packages/expo-cli/lib/test/set-api-key.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-try-expect */
 const withFixture = require('./lib/with-fixture')
 const setApiKey = require('../set-api-key')
 const { readFile } = require('fs/promises')
@@ -28,32 +27,17 @@ describe('expo-cli: set-api-key', () => {
 
   it('should provide a reasonable error when there is no app.json', async () => {
     await withFixture('empty-00', async (projectRoot) => {
-      try {
-        await setApiKey('AABBCCDD', projectRoot)
-        expect('should not be here').toBe(false)
-      } catch (e) {
-        expect(e.message).toMatch(/^Couldn’t find app\.json in/)
-      }
+      await expect(setApiKey('AABBCCDD', projectRoot)).rejects.toThrow(/^Couldn’t find app\.json in/)
     })
   })
 
   it('should provide a reasonable error when app.json is not valid JSON', async () => {
     await withFixture('malformed-json-00', async (projectRoot) => {
-      try {
-        await setApiKey('AABBCCDD', projectRoot)
-        expect('should not be here').toBe(false)
-      } catch (e) {
-        expect(e.message).toMatch(/it wasn’t valid JSON/)
-      }
+      await expect(setApiKey('AABBCCDD', projectRoot)).rejects.toThrow(/it wasn’t valid JSON/)
     })
   })
 
   it('doesn’t swallow any other errors', async () => {
-    try {
-      await setApiKey('AABBCCDD' /* projectRoot is required */)
-      expect('should not be here').toBe(false)
-    } catch (e) {
-      expect(e.message).toMatch(/The "path" argument must be of type string/)
-    }
+    await expect(setApiKey('AABBCCDD')).rejects.toThrow(/The "path" argument must be of type string/)
   })
 })


### PR DESCRIPTION
## Goal

A lot of tests rely on disabling `jest/no-try-expect` eslint rule, but can be rewritten to use `expect(x).toThrow(y)` which is a lot clearer and doesn't require workarounds like `expect('should not be here').toBe(false)`