### PR TITLE
Install less during test runtime

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
       - "publish-expo-app"
     timeout_in_minutes: 20
     agents:
-      queue: "ms-arm-12-6"
+      queue: "opensource-arm-mac-cocoa-12"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.ipa

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
       - "publish-expo-app"
     timeout_in_minutes: 20
     agents:
-      queue: "opensource-arm-mac-cocoa-12"
+      queue: "ms-arm-12-6"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.ipa

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -10,7 +10,7 @@ WORKDIR /app/test/features/fixtures/test-app
 
 RUN mkdir -p /app/test/features/fixures/build
 
-RUN npm i -g gulp-cli node-gyp bunyan rsync turtle-cli@0.24
+RUN npm i -g turtle-cli@0.24
 
 RUN turtle setup:android
 

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -10,10 +10,9 @@ WORKDIR /app/test/features/fixtures/test-app
 
 RUN mkdir -p /app/test/features/fixures/build
 
-RUN yarn global add gulp-cli node-gyp
-RUN yarn add bunyan rsync turtle-cli@0.24
+RUN npm i -g gulp-cli node-gyp bunyan rsync turtle-cli@0.24
 
-RUN node_modules/.bin/turtle setup:android
+RUN turtle setup:android
 
 COPY test/features/fixtures/test-app .
 
@@ -23,7 +22,7 @@ ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 
 CMD EXPO_ANDROID_KEYSTORE_PASSWORD=password \
     EXPO_ANDROID_KEY_PASSWORD=password \
-    node_modules/.bin/turtle build:android \
+    turtle build:android \
     --keystore-path fakekeys.jks \
     --keystore-alias password \
     --output /app/test/features/fixtures/build/output.apk \

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -10,7 +10,7 @@ WORKDIR /app/test/features/fixtures/test-app
 
 RUN mkdir -p /app/test/features/fixures/build
 
-RUN npm i -g turtle-cli@0.24
+RUN yarn global add turtle-cli@0.24
 
 RUN turtle setup:android
 

--- a/test/features/fixtures/test-app/package.json
+++ b/test/features/fixtures/test-app/package.json
@@ -18,8 +18,7 @@
     "react-native-web": "0.17.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.9",
-    "turtle-cli": "~0.24.3"
+    "@babel/core": "^7.12.9"
   },
   "resolutions": {
     "promise": "8.0.2"

--- a/test/scripts/build-ios.sh
+++ b/test/scripts/build-ios.sh
@@ -9,7 +9,7 @@ cd test/features/fixtures/test-app
 
 npm install
 
-./node_modules/.bin/turtle build:ios \
+turtle build:ios \
   -c ./app.json \
   --team-id $APPLE_TEAM_ID \
   --dist-p12-path $EXPO_P12_PATH \


### PR DESCRIPTION
## Goal
Shave some time off of the pipeline runtime by using pre-installed turtle on MacOS and installing fewer dependencies in the Android build image.

After [this PR](https://github.com/bugsnag/platforms-ansible/pull/55) has been applied and merged the target pipeline change will be reverted 