### PR TITLE
Use peer/dev dependencies for Expo packages

### DIFF
--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -16,15 +16,16 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
+    "@bugsnag/core": "^7.16.0",
     "@react-native-community/netinfo": "7.1.3",
     "expo-crypto": "~10.1.1",
     "expo-file-system": "~13.1.0"
   },
-  "devDependencies": {
-    "@bugsnag/core": "^7.16.0"
-  },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^7.0.0",
+    "@react-native-community/netinfo": "7.1.3",
+    "expo-crypto": "~10.1.1",
+    "expo-file-system": "~13.1.0"
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -46,11 +46,14 @@
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^7.16.0",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^7.16.0",
     "@bugsnag/source-maps": "^2.3.0",
-    "bugsnag-build-reporter": "^1.0.1",
+    "bugsnag-build-reporter": "^1.0.1"
+  },
+  "devDependencies": {
     "expo-constants": "~13.0.0"
   },
   "peerDependencies": {
     "expo": ">=33.0.0",
+    "expo-constants": "~13.0.0",
     "react": "*"
   }
 }

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -17,13 +17,13 @@
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.16.0"
-  },
-  "dependencies": {
+    "@bugsnag/core": "^7.16.0",
     "expo-application": "~4.0.1",
     "expo-constants": "~13.0.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^7.0.0",
+    "expo-application": "~4.0.1",
+    "expo-constants": "~13.0.0"
   }
 }

--- a/packages/plugin-expo-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-expo-connectivity-breadcrumbs/package.json
@@ -16,13 +16,12 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
+    "@bugsnag/core": "^7.16.0",
     "@react-native-community/netinfo": "7.1.3"
   },
-  "devDependencies": {
-    "@bugsnag/core": "^7.16.0"
-  },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^7.0.0",
+    "@react-native-community/netinfo": "7.1.3"
   }
 }

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -17,13 +17,13 @@
   "author": "Bugsnag",
   "license": "MIT",
   "devDependencies": {
-    "@bugsnag/core": "^7.16.0"
-  },
-  "dependencies": {
+    "@bugsnag/core": "^7.16.0",
     "expo-constants": "~13.0.0",
     "expo-device": "~4.1.0"
   },
   "peerDependencies": {
-    "@bugsnag/core": "^7.0.0"
+    "@bugsnag/core": "^7.0.0",
+    "expo-constants": "~13.0.0",
+    "expo-device": "~4.1.0"
   }
 }


### PR DESCRIPTION
## Goal

This PR switches our hard dependencies on Expo packages to peer dependencies (and dev dependencies for the unit tests). This means users will no longer be able to get duplicate versions of Expo packages

## Testing

This _should_ have caused the maze runner tests to fail, however the fixture app includes our dev dependencies due to the way it includes our packages

- The package directory is included in the Metro resolver:

  https://github.com/bugsnag/bugsnag-expo/blob/54d8f34d4b87560f188d1662a1698b58e9d9247c/test/features/fixtures/test-app/metro.config.js#L4

- We use Lerna bootstrap in the dockerfile, which includes dev dependencies by default:

  https://github.com/bugsnag/bugsnag-expo/blob/54d8f34d4b87560f188d1662a1698b58e9d9247c/dockerfiles/Dockerfile.expo-publisher#L13

This will be changed in an upcoming PR so that we can test a more realistic scenario. For now, this proves that nothing breaks when our dev/peer dependencies are included in the app