### PR TITLE
Use npm pack & install for Bugsnag packages in test fixture

### DIFF
--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,26 +1,29 @@
-FROM node:12-alpine
+FROM node:14-alpine
 
 RUN apk add --update bash git python3 yarn
 
+# we need at least 8.3.0 for NPM's 'overrides' feature
+RUN npm install -g npm@^8.3.0 expo-cli
+
 WORKDIR /app
 
-COPY package*.json ./
+COPY package.json lerna.json .eslintignore .eslintrc.js jest.config.js ./
 RUN npm install
 
-COPY lerna.json .eslintignore .eslintrc.js jest.config.js ./
-COPY packages ./packages
-COPY bin ./bin
-RUN npx lerna bootstrap
-RUN npx lerna run build --scope "@bugsnag/expo" --scope "@bugsnag/plugin-react"
-
-RUN rm -rf node_modules
-
-WORKDIR /app
-
+COPY packages packages
+COPY bin bin
 COPY test/features test/features
 COPY test/scripts test/scripts
 
-WORKDIR /app/test/features/fixtures/test-app
-RUN yarn install
+# pack the packages and move them into the test fixture
+RUN npm pack packages/*/
+RUN mv *.tgz test/features/fixtures/test-app
 
-CMD node_modules/.bin/expo login -u $EXPO_USERNAME -p $EXPO_PASSWORD && node_modules/.bin/expo publish --release-channel $EXPO_RELEASE_CHANNEL
+WORKDIR /app/test/features/fixtures/test-app
+
+# install the packed packages and delete them
+RUN npm install *.tgz && rm *.tgz
+
+RUN npm install
+
+CMD npx expo login -u $EXPO_USERNAME -p $EXPO_PASSWORD && npx expo publish --release-channel $EXPO_RELEASE_CHANNEL

--- a/test/features/fixtures/test-app/metro.config.js
+++ b/test/features/fixtures/test-app/metro.config.js
@@ -1,25 +1,15 @@
-const { resolve, join } = require('path')
-const { readdirSync } = require('fs')
-
-const pkgs = resolve(__dirname, '../../../../packages')
-
-const watchFolders = [ __dirname, join(__dirname, 'node_modules') ]
-  .concat(
-    readdirSync(pkgs)
-      .map(pkg => join(pkgs, pkg))
-  )
+const { join } = require('path')
 
 module.exports = {
-  watchFolders,
   resolver: {
     extraNodeModules: {
-      'expo': resolve(__dirname, 'node_modules/expo'),
-      'expo-modules-core': resolve(__dirname, 'node_modules/expo-modules-core'),
-      'react-native': resolve(__dirname, 'node_modules/react-native'),
-      'react': resolve(__dirname, 'node_modules/react'),
-      '@babel/runtime': resolve(__dirname, 'node_modules/@babel/runtime'),
-      'promise': resolve(__dirname, 'node_modules/promise'),
-      '@unimodules/core': resolve(__dirname, 'node_modules/@unimodules/core')
+      'expo': `${__dirname}/node_modules/expo`,
+      'expo-modules-core': `${__dirname}/node_modules/expo-modules-core`,
+      'react-native': `${__dirname}/node_modules/react-native`,
+      'react': `${__dirname}/node_modules/react`,
+      '@babel/runtime': `${__dirname}/node_modules/@babel/runtime`,
+      'promise': `${__dirname}/node_modules/promise`,
+      '@unimodules/core': `${__dirname}/node_modules/@unimodules/core`,
     }
   }
 }

--- a/test/features/fixtures/test-app/package.json
+++ b/test/features/fixtures/test-app/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.9"
   },
-  "resolutions": {
+  "overrides": {
     "promise": "8.0.2"
   },
   "private": true


### PR DESCRIPTION
## Goal

This PR changes the mechanism used to include bugsnag-expo packages in the test fixture to use `npm pack` and `npm install`. Previously we relied on adding the `packages` directory to the Metro config, but this causes all of our dependencies (including dev dependencies) to be available in the fixture app

Using `npm pack` is a bit more realistic of real world use without making the fixture setup more complicated. This change means we can't use Yarn anymore as it doesn't really support installing `.tgz` files. However, the only reason we used Yarn in the first place is because of its `resolutions` feature, which NPM now supports in [`overrides`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides)