### PR TITLE
Add npm & yarn flags to pass through to Expo

### DIFF
--- a/packages/expo-cli/cli.js
+++ b/packages/expo-cli/cli.js
@@ -17,7 +17,9 @@ const commands = new Map([
 const cliOpts = [
   { name: 'command', defaultOption: true },
   { name: 'help', type: Boolean },
-  { name: 'project-root', defaultValue: process.cwd() }
+  { name: 'project-root', defaultValue: process.cwd() },
+  { name: 'npm', type: Boolean },
+  { name: 'yarn', type: Boolean }
 ]
 
 const parsedArgs = commandLineArgs(cliOpts, { stopAtFirstUnknown: true })

--- a/packages/expo-cli/commands/install.js
+++ b/packages/expo-cli/commands/install.js
@@ -16,7 +16,13 @@ module.exports = async (argv, globalOpts) => {
     const version = await selectVersion(projectRoot)
 
     console.log(blue('> Installing @bugsnag/expo. This could take a while!'))
-    await install(version, projectRoot)
+
+    const options = {
+      npm: globalOpts.npm,
+      yarn: globalOpts.yarn
+    }
+
+    await install(version, projectRoot, options)
   }
 }
 

--- a/packages/expo-cli/lib/help.js
+++ b/packages/expo-cli/lib/help.js
@@ -16,4 +16,6 @@ module.exports = () => console.log(`
   options
     --project-root  set the path to the expo project
                     (defaults to the current working directory)
+    --npm           install packages using npm
+    --yarn          install packages using Yarn
 `)

--- a/packages/expo-cli/lib/install.js
+++ b/packages/expo-cli/lib/install.js
@@ -1,5 +1,19 @@
 const { spawn } = require('child_process')
 
+function resolveCommand (version, options) {
+  const command = ['install', resolvePackageName(version)]
+
+  if (options.npm) {
+    command.push('--npm')
+  }
+
+  if (options.yarn) {
+    command.push('--yarn')
+  }
+
+  return command
+}
+
 function resolvePackageName (version) {
   if (version === 'latest') {
     return '@bugsnag/expo'
@@ -8,9 +22,9 @@ function resolvePackageName (version) {
   return `@bugsnag/expo@${version}`
 }
 
-module.exports = (version, projectRoot) => {
+module.exports = (version, projectRoot, options) => {
   return new Promise((resolve, reject) => {
-    const command = ['install', resolvePackageName(version)]
+    const command = resolveCommand(version, options)
     const proc = spawn('expo', command, { cwd: projectRoot })
 
     // buffer output in case of an error

--- a/packages/expo-cli/lib/test/install.test.js
+++ b/packages/expo-cli/lib/test/install.test.js
@@ -36,7 +36,109 @@ describe('expo-cli: install', () => {
       jest.doMock('child_process', () => ({ spawn }))
       const install = require('../install')
 
-      const msg = await install('latest', projectRoot)
+      const msg = await install('latest', projectRoot, { npm: false, yarn: false })
+      expect(msg).toBe(undefined)
+    })
+  })
+
+  it('should allow forcing install with NPM', async () => {
+    await withFixture('blank-00', async (projectRoot) => {
+      const spawn = (cmd, args, opts) => {
+        expect(cmd).toBe('expo')
+        expect(args).toEqual(['install', '@bugsnag/expo', '--npm'])
+        expect(opts).toEqual({ cwd: projectRoot })
+
+        const proc = new EventEmitter()
+        // @ts-ignore
+        proc.stdout = new Readable({
+          read () {
+            this.push('some data on stdout')
+            this.push(null)
+          }
+        })
+        // @ts-ignore
+        proc.stderr = new Readable({
+          read () {
+            this.push('some data on stderr')
+            this.push(null)
+          }
+        })
+        setTimeout(() => proc.emit('close', 0), 10)
+        return proc
+      }
+
+      jest.doMock('child_process', () => ({ spawn }))
+      const install = require('../install')
+
+      const msg = await install('latest', projectRoot, { npm: true })
+      expect(msg).toBe(undefined)
+    })
+  })
+
+  it('should allow forcing install with Yarn', async () => {
+    await withFixture('blank-00', async (projectRoot) => {
+      const spawn = (cmd, args, opts) => {
+        expect(cmd).toBe('expo')
+        expect(args).toEqual(['install', '@bugsnag/expo', '--yarn'])
+        expect(opts).toEqual({ cwd: projectRoot })
+
+        const proc = new EventEmitter()
+        // @ts-ignore
+        proc.stdout = new Readable({
+          read () {
+            this.push('some data on stdout')
+            this.push(null)
+          }
+        })
+        // @ts-ignore
+        proc.stderr = new Readable({
+          read () {
+            this.push('some data on stderr')
+            this.push(null)
+          }
+        })
+        setTimeout(() => proc.emit('close', 0), 10)
+        return proc
+      }
+
+      jest.doMock('child_process', () => ({ spawn }))
+      const install = require('../install')
+
+      const msg = await install('latest', projectRoot, { yarn: true })
+      expect(msg).toBe(undefined)
+    })
+  })
+
+  it('should allow forcing install with both NPM and Yarn', async () => {
+    await withFixture('blank-00', async (projectRoot) => {
+      const spawn = (cmd, args, opts) => {
+        expect(cmd).toBe('expo')
+        expect(args).toEqual(['install', '@bugsnag/expo', '--npm', '--yarn'])
+        expect(opts).toEqual({ cwd: projectRoot })
+
+        const proc = new EventEmitter()
+        // @ts-ignore
+        proc.stdout = new Readable({
+          read () {
+            this.push('some data on stdout')
+            this.push(null)
+          }
+        })
+        // @ts-ignore
+        proc.stderr = new Readable({
+          read () {
+            this.push('some data on stderr')
+            this.push(null)
+          }
+        })
+        setTimeout(() => proc.emit('close', 0), 10)
+        return proc
+      }
+
+      jest.doMock('child_process', () => ({ spawn }))
+      const install = require('../install')
+
+      const msg = await install('latest', projectRoot, { npm: true, yarn: true })
       expect(msg).toBe(undefined)
     })
   })
@@ -73,7 +175,7 @@ some data on stdout
 stderr:
 some data on stderr`
 
-      await expect(install('latest', projectRoot)).rejects.toThrow(expected)
+      await expect(install('latest', projectRoot, { npm: false })).rejects.toThrow(expected)
     })
   })
 
@@ -102,7 +204,7 @@ some data on stderr`
     const install = require('../install')
 
     await withFixture('blank-00', async (projectRoot) => {
-      await expect(install('latest', projectRoot)).rejects.toThrow(/floop/)
+      await expect(install('latest', projectRoot, { yarn: false })).rejects.toThrow(/floop/)
     })
   })
 })


### PR DESCRIPTION
## Goal

Followup to #17 to allow explicitly picking NPM or Yarn again. Expo will automatically guess which to use, but also accepts `--npm` & `--yarn` flags to be passed to force its behaviour. We now support the same flags, which are passed through to Expo's CLI

If neither flag is passed, Expo will automatically guess which package manager to use, e.g. Yarn is used if `yarn.lock` is present. If both flags are passed NPM takes precedence, though we don't have any specific logic for this