### PR TITLE
Install dependencies when installing @bugsnag/expo

### DIFF
--- a/packages/expo-cli/lib/detect-installed.js
+++ b/packages/expo-cli/lib/detect-installed.js
@@ -1,13 +1,55 @@
 const { promisify } = require('util')
 const { readFile } = require('fs')
 const { join } = require('path')
+const { DEPENDENCIES } = require('./utils')
 
-module.exports = async (dir) => {
-  try {
-    const pkg = JSON.parse(await promisify(readFile)(join(dir, 'package.json'), 'utf8'))
-    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies, ...pkg.peerDependencies }
-    return allDeps['@bugsnag/expo']
-  } catch (e) {
-    throw new Error('Could not load package.json. Is this the project root?')
+// cache dependencies to avoid potentially parsing package.json multiple times
+// we use a map to store 'directoryName -> parsedJson' to support running against
+// different directories, primarily for the tests
+const cachedDependencies = new Map()
+
+async function getDependencies (directory) {
+  if (!cachedDependencies.has(directory)) {
+    try {
+      const pkg = JSON.parse(await promisify(readFile)(join(directory, 'package.json'), 'utf8'))
+
+      cachedDependencies.set(directory, Object.assign({}, pkg.dependencies, pkg.devDependencies, pkg.peerDependencies))
+    } catch (e) {
+      throw new Error('Could not load package.json. Is this the project root?')
+    }
+  }
+
+  return cachedDependencies.get(directory)
+}
+
+const InstalledState = {
+  NONE: 0,
+  BUGSNAG_EXPO: 1 << 0,
+  ALL_DEPENDENCIES: 1 << 1
+}
+
+module.exports = {
+  InstalledState,
+  detectInstalledState: async directory => {
+    const allDependencies = await getDependencies(directory)
+
+    let installedState = InstalledState.NONE
+
+    if (allDependencies['@bugsnag/expo']) {
+      installedState |= InstalledState.BUGSNAG_EXPO
+    }
+
+    const allDependenciesInstalled = DEPENDENCIES.every(dependency => !!allDependencies[dependency])
+
+    if (allDependenciesInstalled) {
+      installedState |= InstalledState.ALL_DEPENDENCIES
+    }
+
+    return installedState
+  },
+  detectInstalledVersion: async directory => {
+    const allDependencies = await getDependencies(directory)
+
+    return allDependencies['@bugsnag/expo']
   }
 }

--- a/packages/expo-cli/lib/help.js
+++ b/packages/expo-cli/lib/help.js
@@ -7,7 +7,7 @@ module.exports = () => console.log(`
   commands
     init            integrates Bugsnag with an Expo project
                     (this command runs all of the other commands)
-    install         installs @bugsnag/expo
+    install         installs @bugsnag/expo and its dependencies
     insert          inserts @bugsnag/expo into an app
     set-api-key     inserts a provided api key into app.json
     add-hook        configures the Bugsnag postPublish hook in app.json

--- a/packages/expo-cli/lib/insert.js
+++ b/packages/expo-cli/lib/insert.js
@@ -1,7 +1,7 @@
 const { join } = require('path')
 const { readFile, writeFile } = require('fs')
 const { promisify } = require('util')
-const detectInstalled = require('./detect-installed')
+const { detectInstalledVersion } = require('./detect-installed')
 const semver = require('semver')
 
 const importRe = /from ["']@bugsnag\/expo["']/
@@ -34,7 +34,7 @@ Bugsnag.start();
 }
 
 const getCode = async (projectRoot) => {
-  const manifestRange = await detectInstalled(projectRoot)
+  const manifestRange = await detectInstalledVersion(projectRoot)
   const isPostV7 = !manifestRange || semver.ltr('6.99.99', manifestRange)
   return code[isPostV7 ? 'postV7' : 'preV7']
 }

--- a/packages/expo-cli/lib/install.js
+++ b/packages/expo-cli/lib/install.js
@@ -1,7 +1,8 @@
 const { spawn } = require('child_process')
+const { DEPENDENCIES } = require('./utils')
 
 function resolveCommand (version, options) {
-  const command = ['install', resolvePackageName(version)]
+  const command = ['install', resolvePackageName(version)].concat(DEPENDENCIES)
 
   if (options.npm) {
     command.push('--npm')

--- a/packages/expo-cli/lib/test/detect-installed.test.js
+++ b/packages/expo-cli/lib/test/detect-installed.test.js
@@ -1,23 +1,55 @@
 const withFixture = require('./lib/with-fixture')
-const detectInstalled = require('../detect-installed')
+const { InstalledState, detectInstalledState, detectInstalledVersion } = require('../detect-installed')
 
 describe('expo-cli: detect-installed', () => {
-  it('should work on a fresh project', async () => {
-    await withFixture('blank-00', async (projectRoot) => {
-      const version = await detectInstalled(projectRoot)
-      expect(version).toBe(undefined)
+  describe('detectInstalledVersion', () => {
+    it('should work on a fresh project', async () => {
+      await withFixture('blank-00', async (projectRoot) => {
+        const version = await detectInstalledVersion(projectRoot)
+        expect(version).toBe(undefined)
+      })
+    })
+
+    it('should work on project with Bugsnag installed', async () => {
+      await withFixture('already-configured-00', async (projectRoot) => {
+        const version = await detectInstalledVersion(projectRoot)
+        expect(version).toBe('^7.0.0')
+      })
+
+      await withFixture('already-configured-01', async (projectRoot) => {
+        const version = await detectInstalledVersion(projectRoot)
+        expect(version).toBe('7.0.0')
+      })
     })
   })
 
-  it('should work on project with Bugsnag installed', async () => {
-    await withFixture('already-configured-00', async (projectRoot) => {
-      const version = await detectInstalled(projectRoot)
-      expect(version).toBe('^7.0.0')
+  describe('detectInstalledState', () => {
+    it('should return "NONE" when Bugsnag and dependencies are missing', async () => {
+      await withFixture('blank-00', async (projectRoot) => {
+        const state = await detectInstalledState(projectRoot)
+        expect(state).toBe(InstalledState.NONE)
+      })
     })
 
-    await withFixture('already-configured-01', async (projectRoot) => {
-      const version = await detectInstalled(projectRoot)
-      expect(version).toBe('7.0.0')
+    it('should return "BUGSNAG_EXPO" when Bugsnag is installed but dependencies are missing', async () => {
+      await withFixture('already-installed-00', async (projectRoot) => {
+        const state = await detectInstalledState(projectRoot)
+        expect(state).toBe(InstalledState.BUGSNAG_EXPO)
+      })
+    })
+
+    it('should return "ALL_DEPENDENCIES" when Bugsnag is not installed but dependencies are', async () => {
+      await withFixture('dependencies-only-00', async (projectRoot) => {
+        const state = await detectInstalledState(projectRoot)
+        expect(state).toBe(InstalledState.ALL_DEPENDENCIES)
+      })
+    })
+
+    it('should return "BUGSNAG_EXPO | ALL_DEPENDENCIES" when both Bugsnag and dependencies are installed', async () => {
+      await withFixture('already-installed-01', async (projectRoot) => {
+        const state = await detectInstalledState(projectRoot)
+        expect(state).toBe(InstalledState.BUGSNAG_EXPO | InstalledState.ALL_DEPENDENCIES)
+      })
     })
   })
 })

--- a/packages/expo-cli/lib/test/fixtures/dependencies-only-00/App.js
+++ b/packages/expo-cli/lib/test/fixtures/dependencies-only-00/App.js
@@ -1,0 +1,21 @@
+const React = require('react')
+const { StyleSheet, Text, View } = require('react-native')
+
+export default class App extends React.Component {
+  render () {
+    return (
+      <View style={styles.container}>
+        <Text>Hello Expo!</Text>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+})

--- a/packages/expo-cli/lib/test/fixtures/dependencies-only-00/app.json
+++ b/packages/expo-cli/lib/test/fixtures/dependencies-only-00/app.json
@@ -1,0 +1,39 @@
+{
+  "expo": {
+    "name": "Bugsnag test fixture",
+    "slug": "bugsnag-test-fixture",
+    "privacy": "unlisted",
+    "sdkVersion": "32.0.0",
+    "platforms": [
+      "ios",
+      "android"
+    ],
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "extra": {
+      "bugsnag": {
+        "apiKey": "XoXoXoXoXoXo"
+      }
+    },
+    "hooks": {
+      "postPublish": [
+        {
+          "file": "@bugsnag/expo/hooks/post-publish.js",
+          "config": {}
+        }
+      ]
+    }
+  }
+}

--- a/packages/expo-cli/lib/test/fixtures/dependencies-only-00/package.json
+++ b/packages/expo-cli/lib/test/fixtures/dependencies-only-00/package.json
@@ -3,7 +3,6 @@
   "private": "true",
   "version": "0.0.0",
   "dependencies": {
-    "@bugsnag/expo": "^7.0.1",
     "@react-native-community/netinfo": "*",
     "expo-application": "*",
     "expo-constants": "*",

--- a/packages/expo-cli/lib/test/install.test.js
+++ b/packages/expo-cli/lib/test/install.test.js
@@ -11,7 +11,16 @@ describe('expo-cli: install', () => {
     await withFixture('blank-00', async (projectRoot) => {
       const spawn = (cmd, args, opts) => {
         expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/expo'])
+        expect(args).toEqual([
+          'install',
+          '@bugsnag/expo',
+          '@react-native-community/netinfo',
+          'expo-application',
+          'expo-constants',
+          'expo-crypto',
+          'expo-device',
+          'expo-file-system'
+        ])
         expect(opts).toEqual({ cwd: projectRoot })
 
         const proc = new EventEmitter()
@@ -45,7 +54,17 @@ describe('expo-cli: install', () => {
     await withFixture('blank-00', async (projectRoot) => {
       const spawn = (cmd, args, opts) => {
         expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/expo', '--npm'])
+        expect(args).toEqual([
+          'install',
+          '@bugsnag/expo',
+          '@react-native-community/netinfo',
+          'expo-application',
+          'expo-constants',
+          'expo-crypto',
+          'expo-device',
+          'expo-file-system',
+          '--npm'
+        ])
         expect(opts).toEqual({ cwd: projectRoot })
 
         const proc = new EventEmitter()
@@ -79,7 +98,17 @@ describe('expo-cli: install', () => {
     await withFixture('blank-00', async (projectRoot) => {
       const spawn = (cmd, args, opts) => {
         expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/expo', '--yarn'])
+        expect(args).toEqual([
+          'install',
+          '@bugsnag/expo',
+          '@react-native-community/netinfo',
+          'expo-application',
+          'expo-constants',
+          'expo-crypto',
+          'expo-device',
+          'expo-file-system',
+          '--yarn'
+        ])
         expect(opts).toEqual({ cwd: projectRoot })
 
         const proc = new EventEmitter()
@@ -113,7 +142,19 @@ describe('expo-cli: install', () => {
     await withFixture('blank-00', async (projectRoot) => {
       const spawn = (cmd, args, opts) => {
         expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/expo', '--npm', '--yarn'])
+        expect(args).toEqual([
+          'install',
+          '@bugsnag/expo',
+          '@react-native-community/netinfo',
+          'expo-application',
+          'expo-constants',
+          'expo-crypto',
+          'expo-device',
+          'expo-file-system',
+          '--npm',
+          '--yarn'
+        ])
+
         expect(opts).toEqual({ cwd: projectRoot })
 
         const proc = new EventEmitter()
@@ -168,7 +209,7 @@ describe('expo-cli: install', () => {
     const install = require('../install')
 
     await withFixture('blank-00', async (projectRoot) => {
-      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/expo"
+      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/expo @react-native-community/netinfo expo-application expo-constants expo-crypto expo-device expo-file-system"
 stdout:
 some data on stdout
 

--- a/packages/expo-cli/lib/utils.js
+++ b/packages/expo-cli/lib/utils.js
@@ -1,2 +1,13 @@
 const process = require('process')
-module.exports.onCancel = () => process.exit()
+
+module.exports = {
+  onCancel: () => process.exit(),
+  DEPENDENCIES: [
+    '@react-native-community/netinfo',
+    'expo-application',
+    'expo-constants',
+    'expo-crypto',
+    'expo-device',
+    'expo-file-system'
+  ]
+}


### PR DESCRIPTION
## Goal

When using `bugsnag-expo-cli` to install `@bugsnag/expo`, we now also need to install our dependencies. This can be done in the same `expo install` command that we currently use to install `@bugsnag/expo`

Currently we present the user with a different confirmation message depending on if `@bugsnag/expo` is already installed in their project:

- `@bugsnag/expo` is not installed:
  > @bugsnag/expo does not appear to be installed, do you want to install it?
- `@bugsnag/expo` is installed:
  > @bugsnag/expo already appears to be installed, do you want to install it anyway?

Now there are four possible states:

- `@bugsnag/expo` is not installed and at least one dependency is missing
  > @bugsnag/expo does not appear to be installed, do you want to install it and its dependencies?
- `@bugsnag/expo` is not installed but all dependencies are installed
  Same message as above
- `@bugsnag/expo` is installed but at least one dependency is missing
  > @bugsnag/expo already appears to be installed, but is missing dependencies. Do you want to install them?
- `@bugsnag/expo` is installed and all dependencies are also installed
  > @bugsnag/expo already appears to be installed, do you want to install it and its dependencies anyway?

