### PR TITLE
Install the matching `@bugsnag/expo` version for the in-use Expo SDK

### DIFF
--- a/packages/expo-cli/lib/test/version-information.test.js
+++ b/packages/expo-cli/lib/test/version-information.test.js
@@ -1,0 +1,46 @@
+const { getBugsnagVersionForExpoVersion } = require('../version-information')
+
+describe('expo-cli: version-information', () => {
+  describe('getBugsnagVersionForExpoVersion', () => {
+    it('should throw an error for SDK versions <33', () => {
+      const expected = new Error('Expo SDK <33 is no longer supported')
+      const testWith = version => () => getBugsnagVersionForExpoVersion(version)
+
+      expect(testWith('32.0.0')).toThrow(expected)
+      expect(testWith('32.99.99')).toThrow(expected)
+      expect(testWith('0.0.0')).toThrow(expected)
+      expect(testWith('1.0.0')).toThrow(expected)
+      expect(testWith('20.0.0')).toThrow(expected)
+      expect(testWith('33.0.0')).not.toThrow()
+    })
+
+    it.each([
+      ['35.0.0', '6.4.4', 36],
+      ['36.1.2', '6.5.3', 37],
+      ['37.0.5', '7.1.1', 38],
+      ['38.6.0', '7.3.5', 39],
+      ['39.89.82', '7.5.5', 40],
+      ['40.2.3', '7.11.0', 42],
+      ['42.2.0', '7.13.2', 43],
+      ['43.0.3', '7.14.2', 44]
+    ])('should return "%s" for SDK version %d', (expoVersion, expectedBugsnagVersion, expectedSdkVersion) => {
+      const version = getBugsnagVersionForExpoVersion(expoVersion)
+
+      expect(version.bugsnagVersion).toBe(expectedBugsnagVersion)
+      expect(version.expoSdkVersion).toBe(expectedSdkVersion)
+      expect(version.isLegacy).toBe(true)
+    })
+
+    it('should return null for unsupported SDK versions', () => {
+      expect(getBugsnagVersionForExpoVersion('999.999.999')).toBeNull()
+    })
+
+    it('should return the correct @bugsnag/expo version for supported SDKs >= 44', () => {
+      const version = getBugsnagVersionForExpoVersion('44.1.2')
+
+      expect(version.bugsnagVersion).toBe('^44.0.0')
+      expect(version.expoSdkVersion).toBe(44)
+      expect(version.isLegacy).toBe(false)
+    })
+  })
+})

--- a/packages/expo-cli/lib/version-information.js
+++ b/packages/expo-cli/lib/version-information.js
@@ -1,0 +1,64 @@
+const semver = require('semver')
+
+// the major version number of the latest Expo SDK we support
+const LATEST_SUPPORTED_EXPO_SDK = 44
+
+class Version {
+  constructor (expoSdkVersion, bugsnagVersion, isLegacy = false) {
+    this.expoSdkVersion = expoSdkVersion
+    this.bugsnagVersion = bugsnagVersion
+    this.isLegacy = isLegacy
+  }
+}
+
+// the Expo version here means versions less than expo version, e.g. expo versions
+// before v36 use @bugsnag/expo v6.4.4
+// Note: this must be in order from lowest Expo SDK version to the highest
+const legacyVersions = [
+  new Version(36, '6.4.4', true),
+  new Version(37, '6.5.3', true),
+  new Version(38, '7.1.1', true),
+  new Version(39, '7.3.5', true),
+  new Version(40, '7.5.5', true),
+  new Version(42, '7.11.0', true),
+  new Version(43, '7.13.2', true),
+  new Version(44, '7.14.2', true)
+]
+
+function isEarlierVersionThan (installedVersion, versionToCompare) {
+  if (!installedVersion) {
+    return false
+  }
+
+  return semver.lt(semver.minVersion(installedVersion), versionToCompare)
+}
+
+function getBugsnagVersionForExpoVersion (installedExpoVersion) {
+  if (isEarlierVersionThan(installedExpoVersion, '33.0.0')) {
+    throw new Error('Expo SDK <33 is no longer supported')
+  }
+
+  const installedExpoMajorVersion = semver.major(semver.coerce(installedExpoVersion))
+
+  // if this is pre SDK v44, find the legacy version that supported it
+  if (isEarlierVersionThan(installedExpoVersion, '44.0.0')) {
+    for (const version of legacyVersions) {
+      if (isEarlierVersionThan(installedExpoVersion, `${version.expoSdkVersion}.0.0`)) {
+        return version
+      }
+    }
+  } else if (installedExpoMajorVersion <= LATEST_SUPPORTED_EXPO_SDK) {
+    // if this is a supported SDK version that's also >= v44 then there is a
+    // corresponding @bugsnag/expo release with the same major version number
+    // i.e. SDK 44 -> @bugsnag/expo v44.0.0
+    return new Version(installedExpoMajorVersion, `^${installedExpoMajorVersion}.0.0`)
+  }
+
+  // the above loop should always reach the return, but it's possible this is an
+  // Expo version that we haven't released support for yet
+  return null
+}
+
+module.exports = {
+  getBugsnagVersionForExpoVersion
+}

--- a/packages/expo/CONTRIBUTING.md
+++ b/packages/expo/CONTRIBUTING.md
@@ -23,6 +23,4 @@ https://github.com/expo/expo/blob/master/packages/expo/bundledNativeModules.json
 
 ## Updating the CLI to install a compatible notifier version
 
-When the version of the bundled native modules changes the notifier will be incompatible with previous Expo SDKs. To prevent installing the conflicting versions, we need to update the CLI using the established pattern in [`packages/expo-cli/commands/install.js`](../expo-cli/commands/install.js).
-
-This should also be added to [the manual setup docs](https://docs.bugsnag.com/platforms/react-native/expo/manual-setup/#installation).
+When a new Expo SDK is released, a new matching `@bugsnag/expo` version needs to be published. For example, for SDK 44 there is a `@bugsnag/expo` v44. To mark the new SDK as supported, update the CLI's `LATEST_SUPPORTED_EXPO_SDK` in [`packages/expo-cli/lib/version-information.js`](../expo-cli/lib/version-information.js)


### PR DESCRIPTION
## Goal

This PR refactors the checks we use to determine the correct `@bugsnag/expo` version for the in-use Expo SDK and adds support for the new versioning scheme

This relies on a new `LATEST_SUPPORTED_EXPO_SDK` constant, which we'll need to increment with each new Expo SDK, but should be easy to change in a script

If an Expo SDK version that we don't yet support is being used then we'll notify the user but allow them to install the latest `@bugsnag/expo` version — it's _likely_ this will work, so long as we fix deprecations before the SDK that removes the old API is released

## Testing

Added some unit tests, but much of this code isn't tested. I've done some manual testing, though you'll get an error if you try it as `@bugsnag/expo` v44 doesn't exist yet