### PR TITLE
Use bugsnag-expo-cli to setup the test fixture

### DIFF
--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,6 +1,6 @@
 FROM node:14-alpine
 
-RUN apk add --update bash git python3 yarn
+RUN apk add --update bash git python3 yarn expect
 
 # we need at least 8.3.0 for NPM's 'overrides' feature
 RUN npm install -g npm@^8.3.0 expo-cli
@@ -21,9 +21,10 @@ RUN mv *.tgz test/features/fixtures/test-app
 
 WORKDIR /app/test/features/fixtures/test-app
 
-# install the packed packages and delete them
-RUN npm install *.tgz && rm *.tgz
+# install the bugsnag-expo-cli and it to setup the fixture
+RUN npm install bugsnag-expo-cli*.tgz && rm bugsnag-expo-cli*.tgz && ./run-bugsnag-expo-cli
 
-RUN npm install
+# install the remaining packages, this also re-installs the correct @bugsnag/expo version
+RUN npm install *.tgz && rm *.tgz
 
 CMD npx expo login -u $EXPO_USERNAME -p $EXPO_PASSWORD && npx expo publish --release-channel $EXPO_RELEASE_CHANNEL

--- a/test/features/fixtures/test-app/app.json
+++ b/test/features/fixtures/test-app/app.json
@@ -23,11 +23,6 @@
     },
     "android": {
       "package": "com.bugsnag.expo.testfixture"
-    },
-    "extra": {
-      "bugsnag": {
-        "apiKey": "645470b8c7f62177e1a723e26c9a48d7"
-      }
     }
   }
 }

--- a/test/features/fixtures/test-app/run-bugsnag-expo-cli
+++ b/test/features/fixtures/test-app/run-bugsnag-expo-cli
@@ -1,0 +1,44 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+set api_key 645470b8c7f62177e1a723e26c9a48d7
+
+# This expect script runs the following commands:
+#   - install
+#   - set-api-key
+#   - add-hook
+#
+# We don't run 'insert' as the fixture app doesn't start Bugsnag in App.js, but
+# uses individual scenario files that may start Bugsnag differently. Similarly,
+# we don't run 'init' as it would run 'insert'
+#
+# TODO: we run 'install' here, but don't actually install the local version of
+#       @bugsnag/expo. Instead we just use the latest version to prove 'install'
+#       works and then re-install with the local version after running this script
+
+# install
+spawn npx bugsnag-expo-cli install
+
+expect "@bugsnag/expo does not appear to be installed, do you want to install it and its dependencies?"
+send -- "y\r"
+
+expect "If you want to install @bugsnag/expo ^44.0.0 hit enter, otherwise type the version you want"
+send -- "latest\r"
+
+expect eof
+
+# set-api-key
+spawn npx bugsnag-expo-cli set-api-key
+
+expect "What is your Bugsnag API key?"
+send "$api_key\r"
+
+expect eof
+
+# add-hook
+spawn npx bugsnag-expo-cli add-hook
+
+expect "Do you want to automatically upload source maps to Bugsnag? (this will modify your app.json)"
+send -- "\r"
+
+expect eof


### PR DESCRIPTION
## Goal

Improves the testing of `bugsnag-expo-cli` by using it to setup the test fixture. If the CLI is broken then either running it will fail or sending events will fail, e.g. if the API key isn't inserted correctly

This is done with an Expect script that runs the following `bugsnag-expo-cli` commands:

- install
- set-api-key
- add-hook

We don't run 'insert' as the fixture app doesn't start Bugsnag in App.js, but uses individual scenario files that may start Bugsnag differently. Similarly, we don't run 'init' as it would run 'insert'

Despite running the install command, we still have to re-install `@bugsnag/expo` to get the correct local version. This can be changed in future to use Artifactory, but that's not a huge benefit as we're still testing that the install command doesn't error