### PR TITLE
Allow bugsnag-js to run the Expo tests on push

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,17 +15,17 @@ steps:
     timeout_in_minutes: 30
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
+      BUGSNAG_JS_BRANCH: ${BUGSNAG_JS_BRANCH}
+      BUGSNAG_JS_COMMIT: ${BUGSNAG_JS_COMMIT}
     plugins:
       - docker-compose#v3.9.0:
           build: expo-publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
-            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
-            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
+            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}-${BUGSNAG_JS_BRANCH}-${BUGSNAG_JS_COMMIT}
       - docker-compose#v3.9.0:
           push:
-            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}
-            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-latest
+            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}-${BUGSNAG_JS_BRANCH}-${BUGSNAG_JS_COMMIT}
 
   - label:  ':docker: Publish expo app'
     key: "publish-expo-app"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,14 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.expo-publisher
+      args:
+        # passed by bugsnag-js when it triggers a build
+        - BUGSNAG_JS_BRANCH
+        - BUGSNAG_JS_COMMIT
+        # needed to use bugsnag-js versions hosted on artifactory
+        - REGISTRY_URL
+        - REG_BASIC_CREDENTIAL
+        - REG_NPM_EMAIL
     environment:
       EXPO_USERNAME:
       EXPO_PASSWORD:

--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,6 +1,6 @@
 FROM node:14-alpine
 
-RUN apk add --update bash git python3 yarn expect
+RUN apk add --update bash git python3 ruby expect
 
 # we need at least 8.3.0 for NPM's 'overrides' feature
 RUN npm install -g npm@^8.3.0 expo-cli
@@ -23,6 +23,17 @@ WORKDIR /app/test/features/fixtures/test-app
 
 # install the bugsnag-expo-cli and it to setup the fixture
 RUN npm install bugsnag-expo-cli*.tgz && rm bugsnag-expo-cli*.tgz && ./run-bugsnag-expo-cli
+
+# set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
+ARG BUGSNAG_JS_BRANCH
+ARG BUGSNAG_JS_COMMIT
+RUN ./set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT
+
+# setup NPM credentials used if this build was triggered from the bugsnag-js repo
+ARG REGISTRY_URL
+ARG REG_BASIC_CREDENTIAL
+ARG REG_NPM_EMAIL
+RUN echo -e "registry=$REGISTRY_URL\n_auth=$REG_BASIC_CREDENTIAL\nemail=$REG_NPM_EMAIL\nalways-auth=true\nunsafe-perm=true" > ~/.npmrc
 
 # install the remaining packages, this also re-installs the correct @bugsnag/expo version
 RUN npm install *.tgz && rm *.tgz

--- a/test/features/fixtures/test-app/set-bugsnag-js-overrides
+++ b/test/features/fixtures/test-app/set-bugsnag-js-overrides
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+
+BRANCH = ARGV[0]
+COMMIT = ARGV[1]
+
+if BRANCH && !COMMIT
+  puts "$BUGSNAG_JS_BRANCH is present but $BUGSNAG_JS_COMMIT is missing!"
+  exit 1
+elsif COMMIT && !BRANCH
+  puts "$BUGSNAG_JS_COMMIT is present but $BUGSNAG_JS_BRANCH is missing!"
+  exit 1
+elsif !COMMIT && !BRANCH
+  puts "Skipping bugsnag-js install as both arguments are missing"
+  exit
+end
+
+require "open3"
+require "tmpdir"
+require "tempfile"
+
+# clone bugsnag-js and run the script to determine its version
+version = Dir.mktmpdir("bugsnag-js") do |directory|
+  Dir.chdir(directory) do
+    system("git clone https://github.com/bugsnag/bugsnag-js.git --branch '#{BRANCH}' --single-branch --depth 100 .", exception: true)
+    system("git checkout '#{COMMIT}'", exception: true)
+
+    env = {
+      "BRANCH_NAME" => BRANCH,
+      "BUILDKITE" => "yes, very much so",
+    }
+
+    Tempfile.create(["get-bugsnag-js-version", ".js"], directory) do |file|
+      file.write("console.log(require('./scripts/common').determineVersion())")
+      file.close # close the file to flush our changes to disk
+
+      output, status = Open3.capture2(env, "node #{file.path}", unsetenv_others: true)
+      output.strip!
+
+      if !status.success? || output.empty?
+        puts "Failed to fetch bugsnag-js version!"
+        exit 1
+      end
+
+      output.split.last
+    end
+  end
+end
+
+puts "Using bugsnag-js version: '#{version}'"
+
+require "json"
+
+# write the version to the 'overrides' field in package.json for each bugsnag-js
+# package used in this repo
+final_json = File.open("package.json") do |file|
+  package_json = JSON.parse(file.read)
+
+  package_json["overrides"].merge!({
+    "@bugsnag/core" => version,
+    "@bugsnag/plugin-browser-session" => version,
+    "@bugsnag/plugin-console-breadcrumbs" => version,
+    "@bugsnag/plugin-network-breadcrumbs" => version,
+    "@bugsnag/plugin-react" => version,
+    "@bugsnag/plugin-react-native-app-state-breadcrumbs" => version,
+    "@bugsnag/plugin-react-native-global-error-handler" => version,
+    "@bugsnag/plugin-react-native-orientation-breadcrumbs" => version,
+    "@bugsnag/plugin-react-native-unhandled-rejection" => version,
+  })
+
+  JSON.pretty_generate(package_json)
+end
+
+puts "Final package.json file: #{final_json}"
+
+File.open("package.json", "w") do |file|
+  file.write(final_json)
+end


### PR DESCRIPTION
## Goal

When a bugsnag-js commit is pushed, it can provide the branch & commit to the bugsnag-expo pipeline. These will be used to run the tests using the bugsnag-js commit that triggered the build, which will allow us to know if a change to bugsnag-js breaks bugsnag-expo

See https://github.com/bugsnag/bugsnag-js/pull/1718 for the bugsnag-js changes

## Design

The bugsnag-js version numbers that get pushed to artifactory are not really possible to reproduce without running the script that generates them in the first place. Unfortunately this can't be done in the bugsnag-js pipeline (without triggering the build via the buildkite API) because a trigger step can't run any logic. This means we have to clone bugsnag-js, checkout the branch/commit and run the script to get the correct bugsnag-js version number

## Testing

Successful build: https://buildkite.com/bugsnag/bugsnag-js/builds/6805
Deliberately broken build: https://buildkite.com/bugsnag/bugsnag-js/builds/6806