### PR TITLE
Update release script to work for this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Then make the release:
 ```
 GITHUB_USER=<your github username> \
 GITHUB_ACCESS_TOKEN=<generate a personal access token> \
-RELEASE_BRANCH=master \
+RELEASE_BRANCH=<the branch to publish a new release from> \
 VERSION=patch \
   docker-compose run release
 ```
@@ -136,7 +136,7 @@ For example:
 ```
 GITHUB_USER=<your github username> \
 GITHUB_ACCESS_TOKEN=<generate a personal access token> \
-RELEASE_BRANCH=master \
+RELEASE_BRANCH=<the branch to publish a new release from> \
 VERSION=preminor \
   docker-compose run release
 ```

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -12,33 +12,15 @@ if [[ -z ${GITHUB_USER:-} ]]; then error_missing_field "GITHUB_USER"; fi
 if [[ -z ${GITHUB_ACCESS_TOKEN:-} ]]; then error_missing_field "GITHUB_ACCESS_TOKEN"; fi
 if [[ -z ${RELEASE_BRANCH:-} ]]; then error_missing_field "RELEASE_BRANCH"; fi
 if [[ -z ${VERSION:-} ]]; then error_missing_field "VERSION"; fi
-if [[ -z ${AWS_ACCESS_KEY_ID:-} ]]; then error_missing_field "AWS_ACCESS_KEY_ID"; fi
-if [[ -z ${AWS_SECRET_ACCESS_KEY:-} ]]; then error_missing_field "AWS_SECRET_ACCESS_KEY"; fi
 
 git clone --single-branch \
   --branch "$RELEASE_BRANCH" \
-  https://"$GITHUB_USER":"$GITHUB_ACCESS_TOKEN"@github.com/bugsnag/bugsnag-js.git
+  https://"$GITHUB_USER":"$GITHUB_ACCESS_TOKEN"@github.com/bugsnag/bugsnag-expo.git
 
-cd /app/bugsnag-js
+cd /app/bugsnag-expo
 
-# "ci" rather than "install" ensures the process doesn't make the work tree dirty by modifying lockfiles
-npm ci
-npm run bootstrap -- --ci
-
-npx lerna run build \
-  --scope @bugsnag/node \
-  --scope @bugsnag/browser \
-  --scope @bugsnag/expo
-
-npx lerna run build \
-  --ignore @bugsnag/node\
-  --ignore @bugsnag/browser \
-  --ignore @bugsnag/expo \
-  --ignore @bugsnag/plugin-electron-app \
-  --ignore @bugsnag/plugin-electron-client-state-persistence
-
-# check if the browser package changed – if it didn't we don't need to upload to the CDN
-BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/js$ || test $? = 1;)
+npm install --package-lock false
+npx lerna bootstrap -- --package-lock false
 
 if [ -v RETRY_PUBLISH ]; then
   npx lerna publish from-package
@@ -52,8 +34,4 @@ else
       npx lerna publish "$VERSION"
       ;;
   esac
-fi
-
-if [ "$BROWSER_PACKAGE_CHANGED" -eq 1 ] || [  -v FORCE_CDN_UPLOAD ]; then
-  npm run cdn-upload
 fi

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -25,19 +25,35 @@ cd /app/bugsnag-js
 npm ci
 npm run bootstrap -- --ci
 
+npx lerna run build \
+  --scope @bugsnag/node \
+  --scope @bugsnag/browser \
+  --scope @bugsnag/expo
+
+npx lerna run build \
+  --ignore @bugsnag/node\
+  --ignore @bugsnag/browser \
+  --ignore @bugsnag/expo \
+  --ignore @bugsnag/plugin-electron-app \
+  --ignore @bugsnag/plugin-electron-client-state-persistence
+
 # check if the browser package changed – if it didn't we don't need to upload to the CDN
 BROWSER_PACKAGE_CHANGED=$(npx lerna changed --parseable | grep -c packages/js$ || test $? = 1;)
 
-case $VERSION in
-  "prerelease" | "prepatch" | "preminor" | "premajor")
-    npx lerna publish "$VERSION" --dist-tag next
-    ;;
+if [ -v RETRY_PUBLISH ]; then
+  npx lerna publish from-package
+else
+  case $VERSION in
+    "prerelease" | "prepatch" | "preminor" | "premajor")
+      npx lerna publish "$VERSION" --dist-tag next
+      ;;
 
-  *)
-    npx lerna publish "$VERSION"
-    ;;
-esac
+    *)
+      npx lerna publish "$VERSION"
+      ;;
+  esac
+fi
 
-if [ "$BROWSER_PACKAGE_CHANGED" -eq 1 ]; then
+if [ "$BROWSER_PACKAGE_CHANGED" -eq 1 ] || [  -v FORCE_CDN_UPLOAD ]; then
   npm run cdn-upload
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,20 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.android-builder-base
 
+  release:
+    build:
+      context: .
+      dockerfile: dockerfiles/Dockerfile.release
+    environment:
+      GITHUB_USER:
+      GITHUB_ACCESS_TOKEN:
+      RELEASE_BRANCH:
+      RETRY_PUBLISH:
+      VERSION:
+    volumes:
+      - ~/.gitconfig:/home/releaser/.gitconfig
+      - ~/.npmrc:/home/releaser/.npmrc
+
 networks:
   default:
     name: ${BUILDKITE_JOB_ID:-js-maze-runner}

--- a/dockerfiles/Dockerfile.release
+++ b/dockerfiles/Dockerfile.release
@@ -1,0 +1,14 @@
+FROM node:14-alpine
+RUN apk add --update git bash python3 make gcc g++ openssh-client curl
+
+RUN addgroup -S admins
+RUN adduser -S releaser -G admins
+
+WORKDIR /app
+
+RUN chown -R releaser:admins /app
+USER releaser
+
+COPY ./bin/release.sh ./
+
+CMD ./release.sh


### PR DESCRIPTION
## Goal

Updates the release script to work in this repo; this is mostly unchanged from bugsnag-js other than:

- removed the CDN upload
- disable package-lock files as they are gitignored (otherwise Lerna tries to commit them and git gets mad about it)

Includes the retry publish changes from https://github.com/bugsnag/bugsnag-js/pull/1709

I've tested this by publishing to a local Verdaccio server