### PR TITLE
Migrate RN app state breadcrumb plugin to this repo

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,6 +33,7 @@ module.exports = {
       'expo-cli',
       'plugin-expo-app',
       'plugin-expo-device',
+      'plugin-expo-app-state-breadcrumbs',
       'plugin-expo-connectivity-breadcrumbs'
     ])
   ]

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -40,7 +40,7 @@
     "@bugsnag/plugin-expo-device": "^7.16.0",
     "@bugsnag/plugin-network-breadcrumbs": "^7.16.0",
     "@bugsnag/plugin-react": "^7.16.0",
-    "@bugsnag/plugin-react-native-app-state-breadcrumbs": "^7.16.0",
+    "@bugsnag/plugin-expo-app-state-breadcrumbs": "^7.16.0",
     "@bugsnag/plugin-expo-connectivity-breadcrumbs": "^7.16.0",
     "@bugsnag/plugin-react-native-global-error-handler": "^7.16.0",
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^7.16.0",

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -29,7 +29,7 @@ const internalPlugins = [
   require('@bugsnag/plugin-expo-app'),
   require('@bugsnag/plugin-console-breadcrumbs'),
   require('@bugsnag/plugin-network-breadcrumbs')([NET_INFO_REACHABILITY_URL, Constants.manifest?.logUrl || Constants.manifest2?.extra?.expoGo?.logUrl]),
-  require('@bugsnag/plugin-react-native-app-state-breadcrumbs'),
+  require('@bugsnag/plugin-expo-app-state-breadcrumbs'),
   require('@bugsnag/plugin-expo-connectivity-breadcrumbs'),
   require('@bugsnag/plugin-react-native-orientation-breadcrumbs'),
   require('@bugsnag/plugin-browser-session'),

--- a/packages/plugin-expo-app-state-breadcrumbs/LICENSE.txt
+++ b/packages/plugin-expo-app-state-breadcrumbs/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) Bugsnag, https://www.bugsnag.com/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/plugin-expo-app-state-breadcrumbs/README.md
+++ b/packages/plugin-expo-app-state-breadcrumbs/README.md
@@ -1,0 +1,7 @@
+# @bugsnag/plugin-expo-app-state-breadcrumbs
+
+This plugin adds the ability to record changes in network state. It is included in the Expo notifier.
+
+## License
+
+This package is free software released under the MIT License. See [LICENSE.txt](./LICENSE.txt) for details.

--- a/packages/plugin-expo-app-state-breadcrumbs/app-state.js
+++ b/packages/plugin-expo-app-state-breadcrumbs/app-state.js
@@ -1,0 +1,11 @@
+const { AppState } = require('react-native')
+
+module.exports = {
+  load: client => {
+    if (!client._isBreadcrumbTypeEnabled('state')) return
+
+    AppState.addEventListener('change', state => {
+      client.leaveBreadcrumb('App state changed', { state }, 'state')
+    })
+  }
+}

--- a/packages/plugin-expo-app-state-breadcrumbs/package.json
+++ b/packages/plugin-expo-app-state-breadcrumbs/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bugsnag/plugin-expo-app-state-breadcrumbs",
+  "version": "7.16.1",
+  "main": "app-state.js",
+  "description": "@bugsnag/expo plugin to create breadcrumbs when a React Native app enters the foreground/background",
+  "homepage": "https://www.bugsnag.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:bugsnag/bugsnag-expo.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "*.js"
+  ],
+  "author": "Bugsnag",
+  "license": "MIT",
+  "devDependencies": {
+    "@bugsnag/core": "^7.16.1"
+  },
+  "peerDependencies": {
+    "@bugsnag/core": "^7.0.0"
+  }
+}

--- a/packages/plugin-expo-app-state-breadcrumbs/test/app-state.test.js
+++ b/packages/plugin-expo-app-state-breadcrumbs/test/app-state.test.js
@@ -1,0 +1,54 @@
+const { AppState } = require('react-native')
+const Client = require('@bugsnag/core/client')
+const plugin = require('../')
+
+jest.mock('react-native', () => ({
+  AppState: {
+    addEventListener: jest.fn()
+  }
+}))
+
+describe('plugin: expo app state breadcrumbs', () => {
+  beforeEach(() => {
+    AppState.addEventListener.mockReset()
+  })
+
+  it('should create a breadcrumb when the AppState#change event happens', () => {
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', plugins: [plugin] })
+
+    expect(AppState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+    const _cb = AppState.addEventListener.mock.calls[0][1]
+
+    expect(client._breadcrumbs.length).toBe(0)
+
+    _cb('background')
+    expect(client._breadcrumbs.length).toBe(1)
+    expect(client._breadcrumbs[0].type).toBe('state')
+    expect(client._breadcrumbs[0].message).toBe('App state changed')
+    expect(client._breadcrumbs[0].metadata).toEqual({ state: 'background' })
+
+    _cb('active')
+    expect(client._breadcrumbs.length).toBe(2)
+    expect(client._breadcrumbs[1].type).toBe('state')
+    expect(client._breadcrumbs[1].message).toBe('App state changed')
+    expect(client._breadcrumbs[1].metadata).toEqual({ state: 'active' })
+  })
+
+  it('should be enabled when enabledBreadcrumbTypes=null', () => {
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: null, plugins: [plugin] })
+    expect(client).toBe(client)
+    expect(AppState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+  })
+
+  it('should not be enabled when enabledBreadcrumbTypes=[]', () => {
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: [], plugins: [plugin] })
+    expect(client).toBe(client)
+    expect(AppState.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it('should be enabled when enabledBreadcrumbTypes=["state"]', () => {
+    const client = new Client({ apiKey: 'aaaa-aaaa-aaaa-aaaa', enabledBreadcrumbTypes: ['state'], plugins: [plugin] })
+    expect(client).toBe(client)
+    expect(AppState.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+  })
+})

--- a/test/features/fixtures/test-app/set-bugsnag-js-overrides
+++ b/test/features/fixtures/test-app/set-bugsnag-js-overrides
@@ -61,7 +61,6 @@ final_json = File.open("package.json") do |file|
     "@bugsnag/plugin-console-breadcrumbs" => version,
     "@bugsnag/plugin-network-breadcrumbs" => version,
     "@bugsnag/plugin-react" => version,
-    "@bugsnag/plugin-react-native-app-state-breadcrumbs" => version,
     "@bugsnag/plugin-react-native-global-error-handler" => version,
     "@bugsnag/plugin-react-native-orientation-breadcrumbs" => version,
     "@bugsnag/plugin-react-native-unhandled-rejection" => version,


### PR DESCRIPTION
## Goal

Despite the name, `@bugsnag/plugin-react-native-app-state-breadcrumbs` is actually only used by the Expo notifier. I've therefore migrated it to this repo and renamed it `@bugsnag/plugin-expo-app-state-breadcrumbs`. On RN the native notifiers have the same functionality, so it's not needed there