### PR TITLE
Fix potential error with JS branch names in buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,10 +22,12 @@ steps:
           build: expo-publisher
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
           cache-from:
-            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}-${BUGSNAG_JS_BRANCH}-${BUGSNAG_JS_COMMIT}
+            # BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME is BUGSNAG_JS_BRANCH with characters that are illegal in docker cache
+            # names removed
+            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}-${BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME}-${BUGSNAG_JS_COMMIT}
       - docker-compose#v3.9.0:
           push:
-            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}-${BUGSNAG_JS_BRANCH}-${BUGSNAG_JS_COMMIT}
+            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-${BRANCH_NAME}-${BUGSNAG_JS_CACHE_SAFE_BRANCH_NAME}-${BUGSNAG_JS_COMMIT}
 
   - label:  ':docker: Publish expo app'
     key: "publish-expo-app"


### PR DESCRIPTION
## Goal

If a branch contains an illegal character, e.g. '/', docker would get very upset and fail the build. We'll pass over a safe version from bugsnag-js so that this doesn't happen and use that in the cache identifier instead