### PR TITLE
Fix install script error - Cannot read properties of null (reading 'expoSdkVersion')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixes
+
+- Fixed an issue in the `bugsnag-expo-cli` install script when reporting an unsupported version of expo [#31](https://github.com/bugsnag/bugsnag-expo/pull/31)
+
 ## v44.0.0 (2022-04-19)
 
 This release marks a change in the version scheme used by `@bugsnag/expo` and a move to its own repo, [`bugsnag-expo`](https://github.com/bugsnag/bugsnag-expo)

--- a/packages/expo-cli/commands/install.js
+++ b/packages/expo-cli/commands/install.js
@@ -78,7 +78,7 @@ async function selectVersion (directory) {
     // if we were unable to find a suitable @bugsnag/expo version, then we don't
     // support this Expo version yet
     defaultVersion = 'latest'
-    message = `@bugsnag/expo does not yet officially support Expo ${versionInformation.expoSdkVersion}. Do you want to install the most recent available version of @bugsnag/expo instead?`
+    message = `@bugsnag/expo does not yet officially support Expo ${installedExpoVersion}. Do you want to install the most recent available version of @bugsnag/expo instead?`
   } else if (versionInformation.isLegacy) {
     defaultVersion = versionInformation.bugsnagVersion
     message = `It looks like you’re using a version of Expo SDK <${versionInformation.expoSdkVersion}. The last version of Bugsnag that supported your version of Expo is v${versionInformation.bugsnagVersion}`


### PR DESCRIPTION
## Goal

Encountered an error when trying to init bugsnag-expo within an expo ~45 project

## Testing

Attempted to initialise in new repo with changes and successfully received an unsupported version error.