### PR TITLE
V45 next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD
+
+This release adds support for expo 45
+
 ## v44.0.1 (2022-05-12)
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ The following modules are currently used:
 - `@react-native-community/netinfo` (`@bugsnag/delivery-expo`, `@bugsnsag/plugin-expo-connectivity-breadcrumbs`)
 - `expo-application` (`@bugsnag/plugin-expo-app`)
 - `expo-constants` (`@bugsnag/expo`, `@bugsnag/plugin-expo-app`, `@bugsnag/plugin-expo-device`)
-- `expo-crypto` (`@bugsnag/expo`, `@bugsnag/delivery-expo`)
+- `expo-crypto` (`@bugsnag/delivery-expo`)
 - `expo-device` (`@bugsnag/plugin-expo-device`)
 - `expo-file-system` (`@bugsnag/delivery-expo`)
 

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --update bash python3 make gcc g++ musl-dev xvfb-run
 

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -10,7 +10,7 @@ WORKDIR /app/test/features/fixtures/test-app
 
 RUN mkdir -p /app/test/features/fixures/build
 
-RUN yarn global add turtle-cli@0.24
+RUN yarn global add turtle-cli@0.26
 
 RUN turtle setup:android
 

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -10,7 +10,7 @@ WORKDIR /app/test/features/fixtures/test-app
 
 RUN mkdir -p /app/test/features/fixures/build
 
-RUN yarn global add turtle-cli@0.26
+RUN yarn global add turtle-cli@github:expo/turtle
 
 RUN turtle setup:android
 

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -10,7 +10,7 @@ WORKDIR /app/test/features/fixtures/test-app
 
 RUN mkdir -p /app/test/features/fixures/build
 
-RUN yarn global add turtle-cli@github:expo/turtle
+RUN yarn global add turtle-cli@0.26
 
 RUN turtle setup:android
 

--- a/dockerfiles/Dockerfile.expo-android-builder
+++ b/dockerfiles/Dockerfile.expo-android-builder
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-buster
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -35,4 +35,4 @@ RUN echo -e "registry=$REGISTRY_URL\n_auth=$REG_BASIC_CREDENTIAL\nemail=$REG_NPM
 # install the remaining packages, this also re-installs the correct @bugsnag/expo version
 RUN npm install *.tgz && rm *.tgz
 
-CMD npm run expo login -u $EXPO_USERNAME -p $EXPO_PASSWORD && npm run expo publish --release-channel $EXPO_RELEASE_CHANNEL
+CMD ./node_modules/.bin/expo-cli login -u $EXPO_USERNAME -p $EXPO_PASSWORD && ./node_modules/.bin/expo-cli publish --release-channel $EXPO_RELEASE_CHANNEL

--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -35,4 +35,4 @@ RUN echo -e "registry=$REGISTRY_URL\n_auth=$REG_BASIC_CREDENTIAL\nemail=$REG_NPM
 # install the remaining packages, this also re-installs the correct @bugsnag/expo version
 RUN npm install *.tgz && rm *.tgz
 
-CMD npx expo login -u $EXPO_USERNAME -p $EXPO_PASSWORD && npx expo publish --release-channel $EXPO_RELEASE_CHANNEL
+CMD npm run expo login -u $EXPO_USERNAME -p $EXPO_PASSWORD && npm run expo publish --release-channel $EXPO_RELEASE_CHANNEL

--- a/dockerfiles/Dockerfile.expo-publisher
+++ b/dockerfiles/Dockerfile.expo-publisher
@@ -1,9 +1,6 @@
-FROM node:14-alpine
+FROM node:16-alpine
 
 RUN apk add --update bash git python3 ruby expect
-
-# we need at least 8.3.0 for NPM's 'overrides' feature
-RUN npm install -g npm@^8.3.0 expo-cli
 
 WORKDIR /app
 

--- a/dockerfiles/Dockerfile.release
+++ b/dockerfiles/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:16-alpine
 RUN apk add --update git bash python3 make gcc g++ openssh-client curl
 
 RUN addgroup -S admins

--- a/package.json
+++ b/package.json
@@ -13,11 +13,14 @@
         "eslint-plugin-node": "^11.0.0",
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-react": "^7.18.3",
-        "eslint-plugin-standard": "^4.0.1"
+        "eslint-plugin-standard": "^4.0.1",
+        "verdaccio": "^5.10.2"
     },
     "scripts": {
         "bootstrap": "lerna bootstrap",
         "test:unit": "jest",
-        "test:lint": "eslint --report-unused-disable-directives --max-warnings=0 ."
+        "test:lint": "eslint --report-unused-disable-directives --max-warnings=0 .",
+        "local-npm:start": "verdaccio --config ./verdaccio-config.yml",
+        "local-npm:publish-all": "lerna publish --yes --force-publish --exact --no-push --no-git-reset --no-git-tag-version --registry 'http://localhost:4873'"
     }
 }

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -18,14 +18,14 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "@react-native-community/netinfo": "7.1.3",
-    "expo-crypto": "~10.1.1",
-    "expo-file-system": "~13.1.0"
+    "@react-native-community/netinfo": "8.2.0",
+    "expo-crypto": "~10.2.0",
+    "expo-file-system": "~14.0.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "@react-native-community/netinfo": "7.1.3",
-    "expo-crypto": "~10.1.1",
-    "expo-file-system": "~13.1.0"
+    "@react-native-community/netinfo": "8.2.0",
+    "expo-crypto": "~10.2.0",
+    "expo-file-system": "~14.0.0"
   }
 }

--- a/packages/expo-cli/lib/version-information.js
+++ b/packages/expo-cli/lib/version-information.js
@@ -1,7 +1,7 @@
 const semver = require('semver')
 
 // the major version number of the latest Expo SDK we support
-const LATEST_SUPPORTED_EXPO_SDK = 44
+const LATEST_SUPPORTED_EXPO_SDK = 45
 
 class Version {
   constructor (expoSdkVersion, bugsnagVersion, isLegacy = false) {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -37,11 +37,11 @@
     "@bugsnag/plugin-browser-session": "^7.16.0",
     "@bugsnag/plugin-console-breadcrumbs": "^7.16.0",
     "@bugsnag/plugin-expo-app": "^44.0.0",
+    "@bugsnag/plugin-expo-app-state-breadcrumbs": "^44.0.0",
+    "@bugsnag/plugin-expo-connectivity-breadcrumbs": "^44.0.0",
     "@bugsnag/plugin-expo-device": "^44.0.0",
     "@bugsnag/plugin-network-breadcrumbs": "^7.16.0",
     "@bugsnag/plugin-react": "^7.16.0",
-    "@bugsnag/plugin-expo-app-state-breadcrumbs": "^44.0.0",
-    "@bugsnag/plugin-expo-connectivity-breadcrumbs": "^44.0.0",
     "@bugsnag/plugin-react-native-global-error-handler": "^7.16.0",
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^7.16.0",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^7.16.0",
@@ -49,11 +49,11 @@
     "bugsnag-build-reporter": "^1.0.1"
   },
   "devDependencies": {
-    "expo-constants": "~13.0.0"
+    "expo-constants": "~13.1.1"
   },
   "peerDependencies": {
     "expo": ">=33.0.0",
-    "expo-constants": "~13.0.0",
+    "expo-constants": "~13.1.1",
     "react": "*"
   }
 }

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "expo-application": "~4.0.1",
-    "expo-constants": "~13.0.0"
+    "expo-application": "~4.1.0",
+    "expo-constants": "~13.1.1"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "expo-application": "~4.0.1",
-    "expo-constants": "~13.0.0"
+    "expo-application": "~4.1.0",
+    "expo-constants": "~13.1.1"
   }
 }

--- a/packages/plugin-expo-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-expo-connectivity-breadcrumbs/package.json
@@ -18,10 +18,10 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "@react-native-community/netinfo": "7.1.3"
+    "@react-native-community/netinfo": "8.2.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "@react-native-community/netinfo": "7.1.3"
+    "@react-native-community/netinfo": "8.2.0"
   }
 }

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "expo-constants": "~13.0.0",
-    "expo-device": "~4.1.0"
+    "expo-constants": "~13.1.1",
+    "expo-device": "~4.2.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "expo-constants": "~13.0.0",
-    "expo-device": "~4.1.0"
+    "expo-constants": "~13.1.1",
+    "expo-device": "~4.2.0"
   }
 }

--- a/test/features/fixtures/test-app/package.json
+++ b/test/features/fixtures/test-app/package.json
@@ -9,19 +9,19 @@
   "dependencies": {
     "@babel/runtime": "7.4.2",
     "expo-cli": "~5.0.3",
-    "expo": "~44.0.0",
-    "expo-status-bar": "~1.2.0",
+    "expo": "~45.0.0",
+    "expo-status-bar": "~1.3.0",
     "expo-screen-orientation": "~4.1.1",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
-    "react-native": "0.64.3",
-    "react-native-web": "0.17.1"
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-native": "0.68.2",
+    "react-native-web": "0.17.7"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"
   },
   "overrides": {
-    "promise": "8.0.2"
+    "promise": "^8.0.3"
   },
   "private": true
 }

--- a/test/features/fixtures/test-app/run-bugsnag-expo-cli
+++ b/test/features/fixtures/test-app/run-bugsnag-expo-cli
@@ -11,21 +11,6 @@ set api_key 645470b8c7f62177e1a723e26c9a48d7
 # We don't run 'insert' as the fixture app doesn't start Bugsnag in App.js, but
 # uses individual scenario files that may start Bugsnag differently. Similarly,
 # we don't run 'init' as it would run 'insert'
-#
-# TODO: we run 'install' here, but don't actually install the local version of
-#       @bugsnag/expo. Instead we just use the latest version to prove 'install'
-#       works and then re-install with the local version after running this script
-
-# install
-spawn npx bugsnag-expo-cli install
-
-expect "@bugsnag/expo does not appear to be installed, do you want to install it and its dependencies?"
-send -- "y\r"
-
-expect "If you want to install @bugsnag/expo ^44.0.0 hit enter, otherwise type the version you want"
-send -- "latest\r"
-
-expect eof
 
 # set-api-key
 spawn npx bugsnag-expo-cli set-api-key

--- a/verdaccio-config.yml
+++ b/verdaccio-config.yml
@@ -1,0 +1,28 @@
+storage: .verdaccio
+auth:
+  htpasswd:
+    file: .verdaccio/htpasswd
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@bugsnag/safe-json-stringify':
+    access: $anonymous
+    proxy: npmjs
+  '@bugsnag/cuid':
+    access: $anonymous
+    proxy: npmjs
+  'bugsnag-expo-cli':
+    access: $anonymous
+    publish: $anonymous
+    proxy: npmjs
+  '@bugsnag/*':
+    access: $anonymous
+    publish: $anonymous
+    proxy: npmjs
+  '@*/*':
+    access: $anonymous
+    proxy: npmjs
+  '**':
+    access: $anonymous
+    proxy: npmjs


### PR DESCRIPTION
## Goal

To support expo v45

## Changeset

- Bumped dependencies to match those used in expo 45
- Added tooling to assist in local development / testing
- Updated expo-publisher build stage to use expo-cli from node_modules instead of globally installing (pipeline performance improvement)
- Remove unnecessary test to install last version of `bugsnag-expo-cli` from npm registry

## Testing

Manually tested the following features on both iOS and android simulators, using a bootstrapped expo 45 project:

- Startup
- Feature flags
- Uncaught error
- Unhandled promise rejection
- Bugsnag.notify()
- Offline reporting