### PR TITLE
[PLAT-8308] Add isStarted property to notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Added
+
+- Added `isStarted` property to expo notifier to check whether Bugsnag has initialized [#34](https://github.com/bugsnag/bugsnag-expo/pull/34)
+
 ## v44.0.1 (2022-05-12)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `isStarted` property to expo notifier to check whether Bugsnag has initialized [#34](https://github.com/bugsnag/bugsnag-expo/pull/34)
+- Added `Bugsnag.isStarted()` to check whether Bugsnag has initialized [#34](https://github.com/bugsnag/bugsnag-expo/pull/34)
 
 ## v44.0.1 (2022-05-12)
 

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -79,7 +79,7 @@ const Bugsnag = {
     Bugsnag._client = Bugsnag.createClient(opts)
     return Bugsnag._client
   },
-  get isStarted () {
+  isStarted: () => {
     return Bugsnag._client != null
   }
 }

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -78,6 +78,9 @@ const Bugsnag = {
     }
     Bugsnag._client = Bugsnag.createClient(opts)
     return Bugsnag._client
+  },
+  get isStarted () {
+    return Bugsnag._client != null
   }
 }
 

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -114,11 +114,11 @@ describe('expo notifier', () => {
 
   describe('isStarted property', () => {
     it('returns false when Bugsnag has not been initialised', () => {
-      expect(Bugsnag.isStarted).toBe(false)
+      expect(Bugsnag.isStarted()).toBe(false)
     })
     it('returns true when Bugsnag has been initialised', () => {
       Bugsnag.start({ apiKey: API_KEY })
-      expect(Bugsnag.isStarted).toBe(true)
+      expect(Bugsnag.isStarted()).toBe(true)
     })
   })
 

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -112,6 +112,16 @@ describe('expo notifier', () => {
     })
   })
 
+  describe('isStarted property', () => {
+    it('returns false when Bugsnag has not been initialised', () => {
+      expect(Bugsnag.isStarted).toBe(false)
+    })
+    it('returns true when Bugsnag has been initialised', () => {
+      Bugsnag.start({ apiKey: API_KEY })
+      expect(Bugsnag.isStarted).toBe(true)
+    })
+  })
+
   it('accepts plugins', () => {
     Bugsnag.start({
       apiKey: API_KEY,

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -3,7 +3,9 @@ import { BugsnagStatic, Config, Client } from '@bugsnag/core'
 type ExpoConfig = Partial<Config>
 interface ExpoBugsnagStatic extends BugsnagStatic {
   start(apiKeyOrOpts?: string | ExpoConfig): Client
+  isStarted: boolean
 }
+
 declare const Bugsnag: ExpoBugsnagStatic
 
 export default Bugsnag

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -3,7 +3,7 @@ import { BugsnagStatic, Config, Client } from '@bugsnag/core'
 type ExpoConfig = Partial<Config>
 interface ExpoBugsnagStatic extends BugsnagStatic {
   start(apiKeyOrOpts?: string | ExpoConfig): Client
-  isStarted: boolean
+  isStarted(): boolean
 }
 
 declare const Bugsnag: ExpoBugsnagStatic


### PR DESCRIPTION
## Goal

Add the `isStarted` property to notifier similar to the current android implementation, to check whether Bugsnag has been initialised

## Testing

Added appropriate unit tests