### PR TITLE
[PLAT-8778] EAS sourcemaps plugin monorepo compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `Bugsnag.isStarted()` to check whether Bugsnag has initialized [#34](https://github.com/bugsnag/bugsnag-expo/pull/34)
 - (plugin-expo-eas-sourcemaps) Add minimum version check to sourcemap plugin [#45](https://github.com/bugsnag/bugsnag-expo/pull/45)
+- (bugsnag-expo-cli) Improve monorepo compatibility for plugin-expo-eas-sourcemaps installation [#49](https://github.com/bugsnag/bugsnag-expo/pull/49)
 
 ## v45.1.0 (2022-07-28)
 

--- a/packages/expo-cli/lib/configure-plugin.js
+++ b/packages/expo-cli/lib/configure-plugin.js
@@ -73,6 +73,11 @@ module.exports = async (projectRoot) => {
       if (!packageJson.workspaces.nohoist.includes(sourceMaps)) {
         packageJson.workspaces.nohoist.push(sourceMaps)
       }
+      if (withYarnV2) {
+        packageJson.installConfig = packageJson.installConfig || {}
+        packageJson.installConfig.hoistingLimits = 'workspaces'
+      }
+
       await promisify(writeFile)(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8')
     } catch (e) {
       // swallow and rethrow for errors that we can produce better messaging

--- a/packages/expo-cli/lib/configure-plugin.js
+++ b/packages/expo-cli/lib/configure-plugin.js
@@ -73,10 +73,6 @@ module.exports = async (projectRoot) => {
       if (!packageJson.workspaces.nohoist.includes(sourceMaps)) {
         packageJson.workspaces.nohoist.push(sourceMaps)
       }
-      if (!withYarnClassic) {
-        packageJson.installConfig = packageJson.installConfig || {}
-        packageJson.installConfig.hoistingLimits = 'workspaces'
-      }
 
       await promisify(writeFile)(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8')
     } catch (e) {

--- a/packages/expo-cli/lib/configure-plugin.js
+++ b/packages/expo-cli/lib/configure-plugin.js
@@ -65,13 +65,15 @@ module.exports = async (projectRoot) => {
       const sourceMaps = '@bugsnag/source-maps'
       const packageJsonPath = join(projectRoot, 'package.json')
       const packageJson = JSON.parse(await promisify(readFile)(packageJsonPath))
-      packageJson.workspaces = packageJson.workspaces || {}
-      packageJson.workspaces.nohoist = packageJson.workspaces.nohoist || []
-      if (!packageJson.workspaces.nohoist.includes(plugin)) {
-        packageJson.workspaces.nohoist.push(plugin)
-      }
-      if (!packageJson.workspaces.nohoist.includes(sourceMaps)) {
-        packageJson.workspaces.nohoist.push(sourceMaps)
+
+      if (withYarnClassic) {
+        packageJson.workspaces = packageJson.workspaces || {}
+        packageJson.workspaces.nohoist = packageJson.workspaces.nohoist || []
+        if (!packageJson.workspaces.nohoist.includes(plugin)) packageJson.workspaces.nohoist.push(plugin)
+        if (!packageJson.workspaces.nohoist.includes(sourceMaps)) packageJson.workspaces.nohoist.push(sourceMaps)
+      } else {
+        packageJson.installConfig = packageJson.installConfig || {}
+        packageJson.installConfig.hoistingLimits = 'workspaces'
       }
 
       await promisify(writeFile)(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8')

--- a/packages/expo-cli/lib/configure-plugin.js
+++ b/packages/expo-cli/lib/configure-plugin.js
@@ -18,11 +18,7 @@ function usingWorkspaces (projectRoot) {
     proc.on('error', err => { reject(err) })
 
     proc.on('close', code => {
-      if (code === 0) {
-        resolve(true)
-      }
-
-      resolve(false)
+      resolve(code === 0)
     })
   })
 }

--- a/packages/expo-cli/lib/configure-plugin.js
+++ b/packages/expo-cli/lib/configure-plugin.js
@@ -1,8 +1,31 @@
 const { join } = require('path')
 const { readFile, writeFile } = require('fs')
 const { promisify } = require('util')
+const { spawn } = require('child_process')
+const { blue } = require('kleur')
 
 const plugin = '@bugsnag/plugin-expo-eas-sourcemaps'
+
+function usingWorkspaces (projectRoot) {
+  return new Promise((resolve, reject) => {
+    const command = ['workspaces', 'info']
+    const proc = spawn('yarn', command, { cwd: projectRoot })
+
+    // buffer output in case of an error
+    proc.stdout.on('data', d => {})
+    proc.stderr.on('data', d => {})
+
+    proc.on('error', err => { reject(err) })
+
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve(true)
+      }
+
+      resolve(false)
+    })
+  })
+}
 
 module.exports = async (projectRoot) => {
   try {
@@ -25,27 +48,34 @@ module.exports = async (projectRoot) => {
     throw e
   }
 
-  try {
-    const sourceMaps = '@bugsnag/source-maps'
-    const packageJsonPath = join(projectRoot, 'package.json')
-    const packageJson = JSON.parse(await promisify(readFile)(packageJsonPath))
-    packageJson.workspaces = packageJson.workspaces || {}
-    packageJson.workspaces.nohoist = packageJson.workspaces.nohoist || []
-    if (!packageJson.workspaces.nohoist.includes(plugin)) {
-      packageJson.workspaces.nohoist.push(plugin)
+  // are we in a monorepo?
+  const addMonorepoConfig = await usingWorkspaces(projectRoot)
+
+  if (addMonorepoConfig) {
+    console.log(blue('> yarn workspaces detected, updating config'))
+
+    try {
+      const sourceMaps = '@bugsnag/source-maps'
+      const packageJsonPath = join(projectRoot, 'package.json')
+      const packageJson = JSON.parse(await promisify(readFile)(packageJsonPath))
+      packageJson.workspaces = packageJson.workspaces || {}
+      packageJson.workspaces.nohoist = packageJson.workspaces.nohoist || []
+      if (!packageJson.workspaces.nohoist.includes(plugin)) {
+        packageJson.workspaces.nohoist.push(plugin)
+      }
+      if (!packageJson.workspaces.nohoist.includes(sourceMaps)) {
+        packageJson.workspaces.nohoist.push(sourceMaps)
+      }
+      await promisify(writeFile)(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8')
+    } catch (e) {
+      // swallow and rethrow for errors that we can produce better messaging
+      if (e.code === 'ENOENT') {
+        throw new Error(`Couldn’t find package.json in "${projectRoot}".`)
+      }
+      if (e.name === 'SyntaxError') {
+        throw new Error(`Couldn’t parse package.json because it wasn’t valid JSON: "${e.message}"`)
+      }
+      throw e
     }
-    if (!packageJson.workspaces.nohoist.includes(sourceMaps)) {
-      packageJson.workspaces.nohoist.push(sourceMaps)
-    }
-    await promisify(writeFile)(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8')
-  } catch (e) {
-    // swallow and rethrow for errors that we can produce better messaging
-    if (e.code === 'ENOENT') {
-      throw new Error(`Couldn’t find package.json in "${projectRoot}".`)
-    }
-    if (e.name === 'SyntaxError') {
-      throw new Error(`Couldn’t parse package.json because it wasn’t valid JSON: "${e.message}"`)
-    }
-    throw e
   }
 }

--- a/packages/expo-cli/lib/install-plugin.js
+++ b/packages/expo-cli/lib/install-plugin.js
@@ -1,7 +1,7 @@
 const { spawn } = require('child_process')
 
 function resolveCommand (options) {
-  const command = ['install', '@bugsnag/plugin-expo-eas-sourcemaps']
+  const command = ['install', '@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps']
 
   if (options.npm) {
     command.push('--npm')

--- a/packages/expo-cli/lib/install-plugin.js
+++ b/packages/expo-cli/lib/install-plugin.js
@@ -11,6 +11,10 @@ function resolveCommand (options) {
     command.push('--yarn')
   }
 
+  // dev dependencies
+  command.push('--')
+  command.push('-D')
+
   return command
 }
 

--- a/packages/expo-cli/lib/install-plugin.js
+++ b/packages/expo-cli/lib/install-plugin.js
@@ -5,15 +5,15 @@ function resolveCommand (options) {
 
   if (options.npm) {
     command.push('--npm')
+    command.push('--')
+    command.push('--save-dev')
   }
 
   if (options.yarn) {
     command.push('--yarn')
+    command.push('--')
+    command.push('--dev')
   }
-
-  // dev dependencies
-  command.push('--')
-  command.push('-D')
 
   return command
 }

--- a/packages/expo-cli/lib/test/install-plugin.test.js
+++ b/packages/expo-cli/lib/test/install-plugin.test.js
@@ -11,7 +11,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-00', async (projectRoot) => {
       const spawn = (cmd, args, opts) => {
         expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps', '--', '-D'])
+        expect(args).toEqual(['install', '@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
         expect(opts).toEqual({ cwd: projectRoot })
 
         const proc = new EventEmitter()
@@ -43,7 +43,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
           '@bugsnag/source-maps',
           '--npm',
           '--',
-          '-D'
+          '--save-dev'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
 
@@ -76,7 +76,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
           '@bugsnag/source-maps',
           '--yarn',
           '--',
-          '-D'
+          '--dev'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
 
@@ -110,9 +110,11 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
           '@bugsnag/plugin-expo-eas-sourcemaps',
           '@bugsnag/source-maps',
           '--npm',
+          '--',
+          '--save-dev',
           '--yarn',
           '--',
-          '-D'
+          '--dev'
         ])
 
         expect(opts).toEqual({ cwd: projectRoot })
@@ -159,7 +161,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     const installPlugin = require('../install-plugin')
 
     await withFixture('blank-00', async (projectRoot) => {
-      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/plugin-expo-eas-sourcemaps @bugsnag/source-maps -- -D"
+      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/plugin-expo-eas-sourcemaps @bugsnag/source-maps"
 stdout:
 some data on stdout
 

--- a/packages/expo-cli/lib/test/install-plugin.test.js
+++ b/packages/expo-cli/lib/test/install-plugin.test.js
@@ -11,7 +11,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-00', async (projectRoot) => {
       const spawn = (cmd, args, opts) => {
         expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/plugin-expo-eas-sourcemaps'])
+        expect(args).toEqual(['install', '@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
         expect(opts).toEqual({ cwd: projectRoot })
 
         const proc = new EventEmitter()
@@ -40,6 +40,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
         expect(args).toEqual([
           'install',
           '@bugsnag/plugin-expo-eas-sourcemaps',
+          '@bugsnag/source-maps',
           '--npm'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
@@ -70,6 +71,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
         expect(args).toEqual([
           'install',
           '@bugsnag/plugin-expo-eas-sourcemaps',
+          '@bugsnag/source-maps',
           '--yarn'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
@@ -102,6 +104,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
         expect(args).toEqual([
           'install',
           '@bugsnag/plugin-expo-eas-sourcemaps',
+          '@bugsnag/source-maps',
           '--npm',
           '--yarn'
         ])
@@ -150,7 +153,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     const installPlugin = require('../install-plugin')
 
     await withFixture('blank-00', async (projectRoot) => {
-      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/plugin-expo-eas-sourcemaps"
+      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/plugin-expo-eas-sourcemaps @bugsnag/source-maps"
 stdout:
 some data on stdout
 

--- a/packages/expo-cli/lib/test/install-plugin.test.js
+++ b/packages/expo-cli/lib/test/install-plugin.test.js
@@ -11,7 +11,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-00', async (projectRoot) => {
       const spawn = (cmd, args, opts) => {
         expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+        expect(args).toEqual(['install', '@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps', '--', '-D'])
         expect(opts).toEqual({ cwd: projectRoot })
 
         const proc = new EventEmitter()
@@ -41,7 +41,9 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
           'install',
           '@bugsnag/plugin-expo-eas-sourcemaps',
           '@bugsnag/source-maps',
-          '--npm'
+          '--npm',
+          '--',
+          '-D'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
 
@@ -72,7 +74,9 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
           'install',
           '@bugsnag/plugin-expo-eas-sourcemaps',
           '@bugsnag/source-maps',
-          '--yarn'
+          '--yarn',
+          '--',
+          '-D'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
 
@@ -106,7 +110,9 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
           '@bugsnag/plugin-expo-eas-sourcemaps',
           '@bugsnag/source-maps',
           '--npm',
-          '--yarn'
+          '--yarn',
+          '--',
+          '-D'
         ])
 
         expect(opts).toEqual({ cwd: projectRoot })
@@ -153,7 +159,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     const installPlugin = require('../install-plugin')
 
     await withFixture('blank-00', async (projectRoot) => {
-      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/plugin-expo-eas-sourcemaps @bugsnag/source-maps"
+      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/plugin-expo-eas-sourcemaps @bugsnag/source-maps -- -D"
 stdout:
 some data on stdout
 

--- a/packages/plugin-expo-eas-sourcemaps/package.json
+++ b/packages/plugin-expo-eas-sourcemaps/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@bugsnag/source-maps": "^2.3.1",
     "@expo/config-plugins": "^4.1.5"
   },

--- a/packages/plugin-expo-eas-sourcemaps/package.json
+++ b/packages/plugin-expo-eas-sourcemaps/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@bugsnag/source-maps": "^2.3.1",
     "@expo/config-plugins": "^4.1.5"
   },

--- a/packages/plugin-expo-eas-sourcemaps/package.json
+++ b/packages/plugin-expo-eas-sourcemaps/package.json
@@ -20,8 +20,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "@bugsnag/source-maps": "^2.3.1",
-    "@expo/config-plugins": "^4.1.5"
+    "@bugsnag/source-maps": "^2.3.1"
   },
   "author": "Bugsnag",
   "license": "MIT"


### PR DESCRIPTION
## Goal

To enable source-maps plugin to work for an expo project in a monorepo, based on yarn workspaces

## Design

The `@bugsnag/expo-eas-sourcemaps-plugin` updates the android and iOS build configuration with the necessary steps to execute an upload using the `@bugsnag/source-maps` library, and has a hardcoded path to the relevant binaries. (in node_modules)

We must prevent these binaries from being hoisted when using yarn workspaces, so after selecting the option to automatically uploads source maps, the cli tool will:

- Install necessary dev dependencies
- Update `app.json` (expo config) with the new plugin
- Detect version of yarn being used (either classic or version 2 and above)
- Detect whether using yarn workspaces
- Update `package.json` based on the yarn version and workspaces configuration

This will prevent the dependencies from being hoisted, and therefore enable the plugin to upload source maps during `eas build`

## Testing

Installed and built expo project using eas from within a monorepo, and as a standalone application using yarn v1.x and v3.x, tests updated