### PR TITLE
Ensure upload-sourcemaps command is present in expo-cli

### DIFF
--- a/packages/expo-cli/cli.js
+++ b/packages/expo-cli/cli.js
@@ -10,6 +10,7 @@ const commands = new Map([
   ['init', require('./commands/init')],
   ['insert', require('./commands/insert')],
   ['install', require('./commands/install')],
+  ['upload-sourcemaps', require('./commands/upload-sourcemaps')],
   ['set-api-key', require('./commands/set-api-key')]
 ])
 


### PR DESCRIPTION
## Goal

Adds the `upload-sourcemaps` command that's already present into the expo cli tool.