### PR TITLE
v46

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,7 +93,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':runner: expo iOS 12'
+  - label: ':runner: expo iOS 13'
     depends_on:
       - "build-expo-ipa"
       - "expo-maze-runner-image"
@@ -108,9 +108,9 @@ steps:
         command:
           - --app=build/output.ipa
           - --farm=bs
-          - --device=IOS_12
+          - --device=IOS_13
           - --a11y-locator
-          - --appium-version=1.16.0
+          - --appium-version=1.17.0
           - --retry=2
           - --order=random
     concurrency: 9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v46 TBD
+
+This release adds support for expo 46
+
 ## v45.1.1 (2022-08-04)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v46 TBD
+## v46.0.0 (2022-09-09)
 
 This release adds support for expo 46
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## v45.1.1 (2022-08-04)
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ If you add a new dependency please add it to this list.
 
 To check what native module versions are bundled with Expo, check this file:
 
-https://github.com/expo/expo/blob/master/packages/expo/bundledNativeModules.json
+https://github.com/expo/expo/blob/main/packages/expo/bundledNativeModules.json
 
 ## Updating the CLI to install a compatible notifier version
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ To check what native module versions are bundled with Expo, check this file:
 
 https://github.com/expo/expo/blob/main/packages/expo/bundledNativeModules.json
 
+Additionally, `@bugsnag/expo` has a dependency on `promise` that must resolve to the same version used by `react-native` to ensure that we attach our unhandled rejection handler to the same instance of promise used by react-native.
+
 ## Updating the CLI to install a compatible notifier version
 
 When a new Expo SDK is released, a new matching `@bugsnag/expo` version needs to be published. For example, for SDK 44 there is a `@bugsnag/expo` v44. To mark the new SDK as supported, update the CLI's `LATEST_SUPPORTED_EXPO_SDK` in [`packages/expo-cli/lib/version-information.js`](./packages/expo-cli/lib/version-information.js)
@@ -88,17 +90,18 @@ When a new Expo SDK is released, a new matching `@bugsnag/expo` version needs to
 
 To start a release:
 
-- decide on a version number
-- create a new release branch from `next` with the version number in the branch name
-`git checkout -b release/vX.Y.Z`
+- create and push a new branch (e.g. `v46`) from the latest previous branch (e.g. `v45` or `v45-next`)
+- create a new next branch from which the release PR is to be made (e.g. `v46-next`)
+- make the required dependency and CLI changes (see above) for the latest expo version
+- regenerate the expo e2e test fixture using the expo create app cli
 - update the version number and date in the changelog
-- make a PR from your release branch to `master` entitled `Release vX.Y.Z`
-- get the release PR reviewed – all code changes should have been reviewed already, this should be a review of the integration of all changes to be shipped and the changelog
+- make a PR from your release branch (e.g. `v46-next`) to `v46` entitled `Release v46`
+- get the release PR reviewed
 - consider shipping a [prerelease](#prereleases) to aid testing the release
 
 Once the release PR has been approved:
 
-- merge the PR into master
+- merge the PR
 
 You are now ready to make the release. Releases are done using Docker and Docker compose. You do not need to have the release branch checked out on your local machine to make a release – the container pulls a fresh clone of the repo down from GitHub. Prerequisites:
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "45.1.0"
+  "version": "45.1.1"
 }

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -18,14 +18,14 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "@react-native-community/netinfo": "8.2.0",
-    "expo-crypto": "~10.2.0",
-    "expo-file-system": "~14.0.0"
+    "@react-native-community/netinfo": "9.3.0",
+    "expo-crypto": "~11.0.0",
+    "expo-file-system": "~14.1.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "@react-native-community/netinfo": "8.2.0",
-    "expo-crypto": "~10.2.0",
-    "expo-file-system": "~14.0.0"
+    "@react-native-community/netinfo": "9.3.0",
+    "expo-crypto": "~11.0.0",
+    "expo-file-system": "~14.1.0"
   }
 }

--- a/packages/expo-cli/lib/version-information.js
+++ b/packages/expo-cli/lib/version-information.js
@@ -1,7 +1,7 @@
 const semver = require('semver')
 
 // the major version number of the latest Expo SDK we support
-const LATEST_SUPPORTED_EXPO_SDK = 45
+const LATEST_SUPPORTED_EXPO_SDK = 46
 
 class Version {
   constructor (expoSdkVersion, bugsnagVersion, isLegacy = false) {

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bugsnag-expo-cli",
-  "version": "45.1.0",
+  "version": "45.1.1",
   "description": "A tool to help integrate Bugsnag with an Expo app",
   "bin": "cli.js",
   "files": [

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -54,6 +54,7 @@
   "peerDependencies": {
     "expo": ">=33.0.0",
     "expo-constants": "~13.2.3",
+    "promise": "^8",
     "react": "*"
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -49,11 +49,11 @@
     "bugsnag-build-reporter": "^1.0.1"
   },
   "devDependencies": {
-    "expo-constants": "~13.1.1"
+    "expo-constants": "~13.2.3"
   },
   "peerDependencies": {
     "expo": ">=33.0.0",
-    "expo-constants": "~13.1.1",
+    "expo-constants": "~13.2.3",
     "react": "*"
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/expo",
-  "version": "45.0.0",
+  "version": "45.1.1",
   "main": "src/notifier.js",
   "types": "types/bugsnag.d.ts",
   "description": "Bugsnag error reporter for Expo applications",

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "expo-application": "~4.1.0",
-    "expo-constants": "~13.1.1"
+    "expo-application": "~4.2.2",
+    "expo-constants": "~13.2.3"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "expo-application": "~4.1.0",
-    "expo-constants": "~13.1.1"
+    "expo-application": "~4.2.2",
+    "expo-constants": "~13.2.3"
   }
 }

--- a/packages/plugin-expo-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-expo-connectivity-breadcrumbs/package.json
@@ -18,10 +18,10 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "@react-native-community/netinfo": "8.2.0"
+    "@react-native-community/netinfo": "9.3.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "@react-native-community/netinfo": "8.2.0"
+    "@react-native-community/netinfo": "9.3.0"
   }
 }

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "expo-constants": "~13.1.1",
-    "expo-device": "~4.2.0"
+    "expo-constants": "~13.2.3",
+    "expo-device": "~4.3.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "expo-constants": "~13.1.1",
-    "expo-device": "~4.2.0"
+    "expo-constants": "~13.2.3",
+    "expo-device": "~4.3.0"
   }
 }

--- a/test/features/feature_flags.feature
+++ b/test/features/feature_flags.feature
@@ -5,6 +5,7 @@ Background:
   And I click the element "featureFlags"
 
 Scenario: feature flags are attached to unhandled errors
+  When I clear any error dialogue
   Given the element "unhandledErrorWithFeatureFlagsButton" is present
   When I click the element "unhandledErrorWithFeatureFlagsButton"
   Then I wait to receive an error
@@ -20,6 +21,7 @@ Scenario: feature flags are attached to unhandled errors
     | from global on error 3 | 111            |
 
 Scenario: feature flags are attached to handled errors
+  When I clear any error dialogue
   Given the element "handledErrorWithFeatureFlagsButton" is present
   When I click the element "handledErrorWithFeatureFlagsButton"
   Then I wait to receive an error
@@ -35,6 +37,7 @@ Scenario: feature flags are attached to handled errors
     | from notify on error   | notify 7636390 |
 
 Scenario: feature flags can be cleared entirely with an unhandled error
+  When I clear any error dialogue
   Given the element "unhandledErrorClearFeatureFlagsButton" is present
   When I click the element "unhandledErrorClearFeatureFlagsButton"
   Then I wait to receive an error
@@ -43,6 +46,7 @@ Scenario: feature flags can be cleared entirely with an unhandled error
   And the event has no feature flags
 
 Scenario: feature flags can be cleared entirely with a handled error
+  When I clear any error dialogue
   Given the element "handledErrorClearFeatureFlagsButton" is present
   When I click the element "handledErrorClearFeatureFlagsButton"
   Then I wait to receive an error

--- a/test/features/fixtures/test-app/index.js
+++ b/test/features/fixtures/test-app/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/test/features/fixtures/test-app/package.json
+++ b/test/features/fixtures/test-app/package.json
@@ -1,21 +1,30 @@
 {
-  "main": "node_modules/expo/AppEntry.js",
+  "name": "test-app",
+  "version": "1.0.0",
+  "main": "index.js",
   "scripts": {
-    "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
-    "eject": "expo eject"
+    "start": "expo start --dev-client",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
   },
   "dependencies": {
-    "@babel/runtime": "7.4.2",
-    "expo-cli": "~6.0.5",
-    "expo": "~46.0.0",
+    "expo": "~46.0.9",
+    "expo-cli": "^6.0.5",
+    "expo-screen-orientation": "^4.3.0",
+    "expo-splash-screen": "~0.16.2",
     "expo-status-bar": "~1.4.0",
-    "expo-screen-orientation": "~4.3.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-native": "0.68.2",
-    "react-native-web": "0.17.7"
+    "expo-updates": "^0.14.5",
+    "react": "18.0.0",
+    "react-dom": "18.0.0",
+    "react-native": "0.69.4",
+    "react-native-web": "~0.18.7",
+    "@react-native-community/netinfo": "9.3.0",
+    "expo-application": "~4.2.2",
+    "expo-constants": "~13.2.4",
+    "expo-crypto": "~11.0.0",
+    "expo-device": "~4.3.0",
+    "expo-file-system": "~14.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/test/features/fixtures/test-app/package.json
+++ b/test/features/fixtures/test-app/package.json
@@ -20,8 +20,5 @@
   "devDependencies": {
     "@babel/core": "^7.12.9"
   },
-  "overrides": {
-    "promise": "^8.0.3"
-  },
   "private": true
 }

--- a/test/features/fixtures/test-app/package.json
+++ b/test/features/fixtures/test-app/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@babel/runtime": "7.4.2",
-    "expo-cli": "~5.0.3",
-    "expo": "~45.0.0",
-    "expo-status-bar": "~1.3.0",
+    "expo-cli": "~6.0.5",
+    "expo": "~46.0.0",
+    "expo-status-bar": "~1.4.0",
     "expo-screen-orientation": "~4.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/test/features/fixtures/test-app/run-bugsnag-expo-cli-install
+++ b/test/features/fixtures/test-app/run-bugsnag-expo-cli-install
@@ -10,13 +10,15 @@ send -- "\r"
 
 expect eof
 
-# install
-spawn npx bugsnag-expo-cli install
+# This may be required at a later date if we have trouble updating dependencies
 
-expect "@bugsnag/expo already appears to be installed, but is missing dependencies. Do you want to install them?"
-send "y\r"
+# # install
+# spawn npx bugsnag-expo-cli install
 
-expect "If you want to install @bugsnag/expo *"
-send "\r"
+# expect "@bugsnag/expo already appears to be installed, but is missing dependencies. Do you want to install them?"
+# send "y\r"
 
-expect eof
+# expect "If you want to install @bugsnag/expo *"
+# send "\r"
+
+# expect eof

--- a/test/features/fixtures/test-app/run-bugsnag-expo-cli-install
+++ b/test/features/fixtures/test-app/run-bugsnag-expo-cli-install
@@ -10,7 +10,10 @@ send -- "\r"
 
 expect eof
 
-# This may be required at a later date if we have trouble updating dependencies
+# This code was originally present to install peer dependencies using the bugsnag-expo-cli.
+# However due to issues with that installation interacting with local packages and yarn, it was more consistent to
+# add the peer dependencies directly to the application.
+# The code is kept here as a reminder of the original process in case we need to re-visit it in the future.
 
 # # install
 # spawn npx bugsnag-expo-cli install

--- a/test/features/steps/browserstack_steps.rb
+++ b/test/features/steps/browserstack_steps.rb
@@ -33,7 +33,6 @@ rescue Selenium::WebDriver::Error::UnknownError
 end
 
 When("I clear any error dialogue") do
-  return if Maze.driver.capabilities['os'].eql?('ios')
   # It can take multiple clicks to clear a dialog,
   # so keep pressing until nothing is pressed
   keep_clicking = true

--- a/test/features/steps/browserstack_steps.rb
+++ b/test/features/steps/browserstack_steps.rb
@@ -22,3 +22,24 @@ Then("the event {string} equals the current OS name") do |field_path|
 
   Maze.check.equal(expected, actual_value)
 end
+
+def click_if_present(element)
+  return false unless Maze.driver.wait_for_element(element, 1)
+
+  Maze.driver.click_element_if_present(element)
+rescue Selenium::WebDriver::Error::UnknownError
+  # Ignore Appium errors (e.g. during an ANR)
+  return false
+end
+
+When("I clear any error dialogue") do
+  return if Maze.driver.capabilities['os'].eql?('ios')
+  # It can take multiple clicks to clear a dialog,
+  # so keep pressing until nothing is pressed
+  keep_clicking = true
+  while keep_clicking
+    keep_clicking = click_if_present('android:id/button1') ||
+                    click_if_present('android:id/aerr_close') ||
+                    click_if_present('android:id/aerr_restart')
+  end
+end

--- a/test/features/unhandled.feature
+++ b/test/features/unhandled.feature
@@ -5,6 +5,7 @@ Background:
   And I click the element "unhandled"
 
 Scenario: Catching an Unhandled error
+  When I clear any error dialogue
   Given the element "unhandledErrorButton" is present
   When I click the element "unhandledErrorButton"
   Then I wait to receive an error
@@ -14,6 +15,7 @@ Scenario: Catching an Unhandled error
   And the error Bugsnag-Integrity header is valid
 
 Scenario: Catching an Unhandled promise rejection
+  When I clear any error dialogue
   Given the element "unhandledPromiseRejectionButton" is present
   When I click the element "unhandledPromiseRejectionButton"
   Then I wait to receive an error

--- a/test/scripts/build-common.sh
+++ b/test/scripts/build-common.sh
@@ -4,6 +4,8 @@
 rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH/build/*
 # And all previous packages are removed
 git clean -xfdf
+# And the yarn cache is clean
+yarn cache clean --all
 
 # Install expo requirements
 npm install


### PR DESCRIPTION
- update to expo 46 and related dependencies
- add a dependency on `promise^8` to ensure we get the right version of the promise library (the same as used by react-native) when registering our unhandled rejection handler.