### PR TITLE
Enable V46 test fixture to be built locally

### DIFF
--- a/test/scripts/build-common.sh
+++ b/test/scripts/build-common.sh
@@ -33,6 +33,6 @@ yarn import
 
 ./run-bugsnag-expo-cli-install
 
-cp $EXPO_CREDENTIALS_PATH credentials.json
+cp $EXPO_CREDENTIALS_DIR/* .
 
 echo "Common setup complete"


### PR DESCRIPTION
## Goal

Slightly modifies the common build script to pull in the expo credentials into the repo, rather than just the `credentials.json`.  This allows us to set up our credentials locally and build in the same way.

I've verified this builds locally fine, but there may be some intermittent issues with CI until the yarn issue is resolved 100%.