### PR TITLE
Consistently close any error dialogs in e2e tests

### DIFF
--- a/test/features/app.feature
+++ b/test/features/app.feature
@@ -1,7 +1,8 @@
 Feature: Expo App data
 
 Background:
-  Given the element "appFeature" is present
+  Given I clear any error dialogue
+  And the element "appFeature" is present
   And I click the element "appFeature"
 
 Scenario: App data is included by default

--- a/test/features/auto_breadcrumbs.feature
+++ b/test/features/auto_breadcrumbs.feature
@@ -1,6 +1,9 @@
 Feature: Automatically added breadcrumbs
 
-@skip_android_5
+Background:
+  Given I clear any error dialogue
+
+  @skip_android_5
 Scenario: App-state breadcrumbs are captured by default
   Given the element "appStateBreadcrumbs" is present
   And I click the element "appStateBreadcrumbs"

--- a/test/features/device.feature
+++ b/test/features/device.feature
@@ -1,7 +1,8 @@
 Feature: Expo Device data
 
 Background:
-  Given the element "deviceFeature" is present
+  Given I clear any error dialogue
+  And the element "deviceFeature" is present
   And I click the element "deviceFeature"
 
 Scenario: Device data is included by default

--- a/test/features/error_boundary.feature
+++ b/test/features/error_boundary.feature
@@ -1,7 +1,8 @@
 Feature: Error boundaries
 
 Background:
-  Given the element "errorBoundary" is present
+  Given I clear any error dialogue
+  And the element "errorBoundary" is present
   And I click the element "errorBoundary"
 
 Scenario: A render error is captured by an error boundary

--- a/test/features/feature_flags.feature
+++ b/test/features/feature_flags.feature
@@ -1,11 +1,11 @@
 Feature: Feature flags
 
 Background:
-  Given the element "featureFlags" is present
+  Given I clear any error dialogue
+  And the element "featureFlags" is present
   And I click the element "featureFlags"
 
 Scenario: feature flags are attached to unhandled errors
-  When I clear any error dialogue
   Given the element "unhandledErrorWithFeatureFlagsButton" is present
   When I click the element "unhandledErrorWithFeatureFlagsButton"
   Then I wait to receive an error
@@ -21,7 +21,6 @@ Scenario: feature flags are attached to unhandled errors
     | from global on error 3 | 111            |
 
 Scenario: feature flags are attached to handled errors
-  When I clear any error dialogue
   Given the element "handledErrorWithFeatureFlagsButton" is present
   When I click the element "handledErrorWithFeatureFlagsButton"
   Then I wait to receive an error
@@ -37,7 +36,6 @@ Scenario: feature flags are attached to handled errors
     | from notify on error   | notify 7636390 |
 
 Scenario: feature flags can be cleared entirely with an unhandled error
-  When I clear any error dialogue
   Given the element "unhandledErrorClearFeatureFlagsButton" is present
   When I click the element "unhandledErrorClearFeatureFlagsButton"
   Then I wait to receive an error
@@ -46,7 +44,6 @@ Scenario: feature flags can be cleared entirely with an unhandled error
   And the event has no feature flags
 
 Scenario: feature flags can be cleared entirely with a handled error
-  When I clear any error dialogue
   Given the element "handledErrorClearFeatureFlagsButton" is present
   When I click the element "handledErrorClearFeatureFlagsButton"
   Then I wait to receive an error

--- a/test/features/handled.feature
+++ b/test/features/handled.feature
@@ -1,7 +1,8 @@
 Feature: Reporting handled errors
 
 Background:
-  Given the element "handled" is present
+  Given I clear any error dialogue
+  And the element "handled" is present
   And I click the element "handled"
 
 Scenario: Calling notify() with an Error

--- a/test/features/ignore_event.feature
+++ b/test/features/ignore_event.feature
@@ -1,7 +1,8 @@
 Feature: Ignoring an event
 
 Background:
-  Given the element "ignoreEvent" is present
+  Given I clear any error dialogue
+  And the element "ignoreEvent" is present
   And I click the element "ignoreEvent"
 
 Scenario: A event can be ignored by returning false

--- a/test/features/manual_breadcrumbs.feature
+++ b/test/features/manual_breadcrumbs.feature
@@ -1,7 +1,8 @@
 Feature: Manually added breadcrumbs
 
 Background:
-  Given the element "manualBreadcrumbs" is present
+  Given I clear any error dialogue
+  And the element "manualBreadcrumbs" is present
   And I click the element "manualBreadcrumbs"
 
 Scenario: Manual breadcrumbs are enabled when automatic breadcrumbs are disabled

--- a/test/features/metadata.feature
+++ b/test/features/metadata.feature
@@ -1,7 +1,8 @@
 Feature: Metadata
 
 Background:
-  Given the element "metadataFeature" is present
+  Given I clear any error dialogue
+  And the element "metadataFeature" is present
   And I click the element "metadataFeature"
 
 Scenario: Meta data can be set via the client

--- a/test/features/sessions.feature
+++ b/test/features/sessions.feature
@@ -1,7 +1,8 @@
 Feature: Expo sessions
 
 Background:
-  Given the element "sessions" is present
+  Given I clear any error dialogue
+  And the element "sessions" is present
   And I click the element "sessions"
 
 Scenario: Sessions can be automatically delivered

--- a/test/features/unhandled.feature
+++ b/test/features/unhandled.feature
@@ -1,11 +1,11 @@
 Feature: Reporting unhandled errors
 
 Background:
-  Given the element "unhandled" is present
+  Given I clear any error dialogue
+  And the element "unhandled" is present
   And I click the element "unhandled"
 
 Scenario: Catching an Unhandled error
-  When I clear any error dialogue
   Given the element "unhandledErrorButton" is present
   When I click the element "unhandledErrorButton"
   Then I wait to receive an error
@@ -15,7 +15,6 @@ Scenario: Catching an Unhandled error
   And the error Bugsnag-Integrity header is valid
 
 Scenario: Catching an Unhandled promise rejection
-  When I clear any error dialogue
   Given the element "unhandledPromiseRejectionButton" is present
   When I click the element "unhandledPromiseRejectionButton"
   Then I wait to receive an error

--- a/test/features/user.feature
+++ b/test/features/user.feature
@@ -1,7 +1,8 @@
 Feature: User data
 
 Background:
-  Given the element "userFeature" is present
+  Given I clear any error dialogue
+  And the element "userFeature" is present
   And I click the element "userFeature"
 
 Scenario: User data can be set via the client


### PR DESCRIPTION
## Goal

Avoid test flakes on Android by ensuring that any error dialogs (caused by us crashing the app) are consistently closed before running each e2e tests. (I have seen multiple instances recently of a scenario failing due to a crash dialog blocking Appium).

## Design

Used Cucumber `Background` steps in all feature files.

## Testing

Covered by CI, although only time will really tell if it makes matters better.