### PR TITLE
[PLAT-8992] Handle missing app.json

### DIFF
--- a/packages/expo-cli/lib/configure-plugin.js
+++ b/packages/expo-cli/lib/configure-plugin.js
@@ -56,6 +56,7 @@ module.exports = async (projectRoot) => {
   }
 
   // update config
+  conf.expo = conf.expo || {}
   conf.expo.plugins = conf.expo.plugins || []
   if (conf.expo.plugins.includes(plugin)) {
     return plugin + ' is already installed'

--- a/packages/expo-cli/lib/set-api-key.js
+++ b/packages/expo-cli/lib/set-api-key.js
@@ -27,6 +27,7 @@ module.exports = async (apiKey, projectRoot) => {
     }
   }
 
+  conf.expo = conf.expo || {}
   conf.expo.extra = conf.expo.extra || {}
   conf.expo.extra.bugsnag = conf.expo.extra.bugsnag || {}
   conf.expo.extra.bugsnag.apiKey = apiKey

--- a/packages/expo-cli/lib/set-api-key.js
+++ b/packages/expo-cli/lib/set-api-key.js
@@ -3,21 +3,33 @@ const { readFile, writeFile } = require('fs')
 const { promisify } = require('util')
 
 module.exports = async (apiKey, projectRoot) => {
+  const appJsonPath = join(projectRoot, 'app.json')
+  let conf
+
   try {
-    const appJsonPath = join(projectRoot, 'app.json')
-    const conf = JSON.parse(await promisify(readFile)(appJsonPath, 'utf8'))
-    conf.expo.extra = conf.expo.extra || {}
-    conf.expo.extra.bugsnag = conf.expo.extra.bugsnag || {}
-    conf.expo.extra.bugsnag.apiKey = apiKey
-    await promisify(writeFile)(appJsonPath, JSON.stringify(conf, null, 2), 'utf8')
+    conf = JSON.parse(await promisify(readFile)(appJsonPath, 'utf8'))
   } catch (e) {
     // swallow and rethrow for errors that we can produce better messaging for
     if (e.code === 'ENOENT') {
-      throw new Error(`Couldn’t find app.json in "${projectRoot}". Is this the root of your Expo project?`)
-    }
-    if (e.name === 'SyntaxError') {
+      conf = {
+        expo: {
+          extra: {
+            bugsnag: {
+            }
+          }
+        }
+      }
+      // throw new Error(`Couldn’t find app.json in "${projectRoot}". Is this the root of your Expo project?`)
+    } else if (e.name === 'SyntaxError') {
       throw new Error(`Couldn’t parse app.json because it wasn’t valid JSON: "${e.message}"`)
+    } else {
+      throw e
     }
-    throw e
   }
+
+  conf.expo.extra = conf.expo.extra || {}
+  conf.expo.extra.bugsnag = conf.expo.extra.bugsnag || {}
+  conf.expo.extra.bugsnag.apiKey = apiKey
+
+  await promisify(writeFile)(appJsonPath, JSON.stringify(conf, null, 2), 'utf8')
 }

--- a/packages/expo-cli/lib/test/configure-plugin.test.js
+++ b/packages/expo-cli/lib/test/configure-plugin.test.js
@@ -27,9 +27,14 @@ describe('expo-cli: upload sourcemaps configure-plugin', () => {
     })
   })
 
-  it('should provide a reasonable error when there is no app.json', async () => {
+  it('should create a basic file when there is no app.json', async () => {
     await withFixture('empty-00', async (projectRoot) => {
-      await expect(configurePlugin(projectRoot)).rejects.toThrow(/^Couldn’t find app\.json in/)
+      const msg = await configurePlugin(projectRoot)
+      expect(msg).toBe(undefined)
+
+      const appJsonRaw = await readFile(`${projectRoot}/app.json`, 'utf8')
+      const appJson = JSON.parse(appJsonRaw)
+      expect(appJson.expo.plugins).toStrictEqual(['@bugsnag/plugin-expo-eas-sourcemaps'])
     })
   })
 

--- a/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-01/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bugsnag-test-fixture-05",
+  "name": "already-installed-01",
   "private": "true",
   "version": "0.0.0",
   "dependencies": {

--- a/packages/expo-cli/lib/test/set-api-key.test.js
+++ b/packages/expo-cli/lib/test/set-api-key.test.js
@@ -14,7 +14,7 @@ describe('expo-cli: set-api-key', () => {
     })
   })
 
-  it('shouldn’t replaces an existing API key', async () => {
+  it('shouldn’t replace an existing API key', async () => {
     await withFixture('already-configured-00', async (projectRoot) => {
       const msg = await setApiKey('AABBCCDD', projectRoot)
       expect(msg).toBe(undefined)
@@ -25,9 +25,14 @@ describe('expo-cli: set-api-key', () => {
     })
   })
 
-  it('should provide a reasonable error when there is no app.json', async () => {
+  it('should create a basic file with apiKey when there is no app.json', async () => {
     await withFixture('empty-00', async (projectRoot) => {
-      await expect(setApiKey('AABBCCDD', projectRoot)).rejects.toThrow(/^Couldn’t find app\.json in/)
+      const msg = await setApiKey('AABBCCDD', projectRoot)
+      expect(msg).toBe(undefined)
+
+      const appJsonRaw = await readFile(`${projectRoot}/app.json`, 'utf8')
+      const appJson = JSON.parse(appJsonRaw)
+      expect(appJson.expo.extra.bugsnag.apiKey).toBe('AABBCCDD')
     })
   })
 


### PR DESCRIPTION
## Goal

To create a missing `app.json` file when `app.config.[js/ts]` is used

## Design

`app.json` is automatically parsed and included in `app.config.[js/ts]`. Users can then port the customised config into the relevant config files if required

## Changeset

CLI tool changes, unit tests updated

## Testing

Unit tests updated to cover file creation