### PR TITLE
Revert "Update pipeline and build scripts to pick node version"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,7 +31,6 @@ steps:
       queue: "opensource-arm-mac-cocoa-12"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      NODE_VERSION: "14"
     artifact_paths: build/output.apk
     commands:
       - test/scripts/build-android.sh
@@ -44,7 +43,6 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"
-      NODE_VERSION: "14"
     artifact_paths: build/output.ipa
     commands:
       - test/scripts/build-ios.sh

--- a/test/scripts/build-android.sh
+++ b/test/scripts/build-android.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Switch Node Version; Default to Node 14
-[ "${IN_SUBSHELL}" != "$0" ] && exec env IN_SUBSHELL="$0" nave use "${NODE_VERSION:-14}" bash "$0" "$@" || :
-
 ./test/scripts/build-common.sh
 
 cd test/features/fixtures/test-app

--- a/test/scripts/build-common.sh
+++ b/test/scripts/build-common.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -e
 
-# Switch Node Version; Default to Node 14
-[ "${IN_SUBSHELL}" != "$0" ] && exec env IN_SUBSHELL="$0" nave use "${NODE_VERSION:-14}" bash "$0" "$@" || :
-
 # Lets make sure the build folder was cleared out correctly
 rm -rf $BUILDKITE_BUILD_CHECKOUT_PATH/build/*
 # And all previous packages are removed

--- a/test/scripts/build-ios.sh
+++ b/test/scripts/build-ios.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Switch Node Version; Default to Node 14
-[ "${IN_SUBSHELL}" != "$0" ] && exec env IN_SUBSHELL="$0" nave use "${NODE_VERSION:-14}" bash "$0" "$@" || :
-
 ./test/scripts/build-common.sh
 
 cd test/features/fixtures/test-app


### PR DESCRIPTION
Reverts bugsnag/bugsnag-expo#75.

We took another route on the build servers, which should mean not having to select the Node version in the build script (as long as the default of Node 16 is suitable).