### PR TITLE
Update app.json to work with the latest version of EAS CLI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
   - label: ':copyright: License Audit'
     timeout_in_minutes: 20
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: ms-arm-12-8
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.app"
     command: scripts/license_finder.sh
@@ -28,7 +28,7 @@ steps:
     key: "build-expo-apk"
     timeout_in_minutes: 20
     agents:
-      queue: "opensource-arm-mac-cocoa-12"
+      queue: "ms-arm-12-8"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
@@ -39,7 +39,7 @@ steps:
     key: "build-expo-ipa"
     timeout_in_minutes: 20
     agents:
-      queue: "opensource-arm-mac-cocoa-12"
+      queue: "ms-arm-12-8"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
   - label: ':copyright: License Audit'
     timeout_in_minutes: 20
     agents:
-      queue: ms-arm-12-8
+      queue: opensource-arm-mac-cocoa-12
     env:
       DEVELOPER_DIR: "/Applications/Xcode13.app"
     command: scripts/license_finder.sh
@@ -28,7 +28,7 @@ steps:
     key: "build-expo-apk"
     timeout_in_minutes: 20
     agents:
-      queue: "ms-arm-12-8"
+      queue: "opensource-arm-mac-cocoa-12"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
     artifact_paths: build/output.apk
@@ -39,7 +39,7 @@ steps:
     key: "build-expo-ipa"
     timeout_in_minutes: 20
     agents:
-      queue: "ms-arm-12-8"
+      queue: "opensource-arm-mac-cocoa-12"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       DEVELOPER_DIR: "/Applications/Xcode13.4.app"

--- a/test/features/fixtures/test-app/app.json
+++ b/test/features/fixtures/test-app/app.json
@@ -26,6 +26,11 @@
     },
     "plugins": [
       ["./config-plugins/withRemoveiOSNotificationEntitlement"]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "EXPO_EAS_PROJECT_ID"
+      }
+    }
   }
 }

--- a/test/scripts/build-common.sh
+++ b/test/scripts/build-common.sh
@@ -23,6 +23,9 @@ cd test/features/fixtures/test-app
 npm install bugsnag-expo-cli*.tgz
 ./run-bugsnag-expo-cli
 
+# Set EAS Project ID
+sed -i'' -e "s/EAS_PROJECT_ID/$EAS_PROJECT_ID/g" app.json
+
 # set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
 ./set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT
 

--- a/test/scripts/build-common.sh
+++ b/test/scripts/build-common.sh
@@ -24,7 +24,7 @@ npm install bugsnag-expo-cli*.tgz
 ./run-bugsnag-expo-cli
 
 # Set EAS Project ID
-sed -i'' -e "s/EAS_PROJECT_ID/$EAS_PROJECT_ID/g" app.json
+sed -i'' -e "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
 
 # set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
 ./set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT

--- a/test/scripts/build-common.sh
+++ b/test/scripts/build-common.sh
@@ -24,7 +24,7 @@ npm install bugsnag-expo-cli*.tgz
 ./run-bugsnag-expo-cli
 
 # Set EAS Project ID
-sed -i'' -e "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
+sed -i '' "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
 
 # set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
 ./set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT


### PR DESCRIPTION
## Goal

Update the `app.json` for the test-app to work with the latest version of EAS CLI

## Design

Project ID is injected at build time from the environment so that it is not added to the repo.

## Changeset

Update `build-common.sh` to inject the EAS project ID into the `app.json` at point of build.

## Testing

https://buildkite.com/bugsnag/bugsnag-expo/builds/1197#_