### PR TITLE
Update app.json to work with the latest version of EAS CLI

### DIFF
--- a/test/features/fixtures/test-app/app.json
+++ b/test/features/fixtures/test-app/app.json
@@ -26,6 +26,11 @@
     },
     "plugins": [
       ["./config-plugins/withRemoveiOSNotificationEntitlement"]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "EXPO_EAS_PROJECT_ID"
+      }
+    }
   }
 }

--- a/test/scripts/build-common.sh
+++ b/test/scripts/build-common.sh
@@ -23,6 +23,9 @@ cd test/features/fixtures/test-app
 npm install bugsnag-expo-cli*.tgz
 ./run-bugsnag-expo-cli
 
+# Set EAS Project ID
+sed -i '' "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
+
 # set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
 ./set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT
 


### PR DESCRIPTION
## Goal

Update the `app.json` for the test-app to work with the latest version of EAS CLI

## Design

Project ID is injected at build time from the environment so that it is not added to the repo.

## Changeset

Update `build-common.sh` to inject the EAS project ID into the `app.json` at point of build.

## Testing

covered by ci