### PR TITLE
Ensure package.json has an `overrides` field

### DIFF
--- a/test/features/fixtures/test-app/set-bugsnag-js-overrides
+++ b/test/features/fixtures/test-app/set-bugsnag-js-overrides
@@ -55,6 +55,7 @@ require "json"
 final_json = File.open("package.json") do |file|
   package_json = JSON.parse(file.read)
 
+  package_json["overrides"] ||= {}
   package_json["overrides"].merge!({
     "@bugsnag/core" => version,
     "@bugsnag/plugin-browser-session" => version,


### PR DESCRIPTION
## Goal

This fixes CI on the `v47/next` branch — the other versions have an `overrides` field in the package.json directly, though it makes much more sense to add one if it doesn't exist (as done in this PR)