### PR TITLE
[PLAT-9224] Add app.versionCode/app.bundleVersion metadata and add codeBundleId config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- Fixed an issue with source map matching for standalone Android apps built using EAS Build [#92](https://github.com/bugsnag/bugsnag-expo/pull/92)
+
+### Added
+
+- Added `app.versionCode` (Android) and `app.bundleVersion` (iOS) metadata for standalone apps [#92](https://github.com/bugsnag/bugsnag-expo/pull/92)
+- Added `codeBundleId` configuration option [#92](https://github.com/bugsnag/bugsnag-expo/pull/92)
+
 ## v47.0.0 (2022-11-21)
 
 This release adds support for expo 47

--- a/packages/expo/src/config.js
+++ b/packages/expo/src/config.js
@@ -2,6 +2,7 @@
 
 const { schema } = require('@bugsnag/core/config')
 const Constants = require('expo-constants').default
+const stringWithLength = require('@bugsnag/core/lib/validators/string-with-length')
 
 // If the developer property is not present in the manifest, it means the app is
 // not connected to a development tool and is either a published app running in
@@ -30,6 +31,11 @@ module.exports = {
       if (IS_PRODUCTION_MODE) return 'local-prod'
       return 'local-dev'
     }
+  },
+  codeBundleId: {
+    defaultValue: () => undefined,
+    message: 'should be a string',
+    validate: val => (val === undefined || stringWithLength(val))
   }
 }
 

--- a/packages/expo/src/config.js
+++ b/packages/expo/src/config.js
@@ -35,7 +35,7 @@ module.exports = {
   codeBundleId: {
     defaultValue: () => undefined,
     message: 'should be a string',
-    validate: val => (val === undefined || stringWithLength(val))
+    validate: val => val === undefined || stringWithLength(val)
   }
 }
 

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -137,6 +137,7 @@ describe('expo notifier', () => {
     Bugsnag.start({
       apiKey: API_KEY,
       appVersion: '1.2.3',
+      codeBundleId: '691f4728-4bf5-4da3-a954-ea9a10fa17d2',
       appType: 'worker',
       autoDetectErrors: true,
       enabledErrorTypes: {
@@ -166,7 +167,7 @@ describe('expo notifier', () => {
       expect(onError).toHaveBeenCalled()
 
       expect(_delivery.sendSession).toHaveBeenCalledWith(expect.objectContaining({
-        app: expect.objectContaining({ releaseStage: 'production', version: '1.2.3', type: 'worker' }),
+        app: expect.objectContaining({ releaseStage: 'production', version: '1.2.3', type: 'worker', codeBundleId: '691f4728-4bf5-4da3-a954-ea9a10fa17d2' }),
         device: expect.objectContaining({ manufacturer: 'Google', model: 'Pixel 4', modelNumber: undefined, osName: 'android', totalMemory: undefined }),
         sessions: expect.arrayContaining([expect.objectContaining({ id: expect.any(String), startedAt: expect.any(Date) })])
       }))
@@ -175,7 +176,7 @@ describe('expo notifier', () => {
         apiKey: '030bab153e7c2349be364d23b5ae93b5',
         events: expect.arrayContaining([
           expect.objectContaining({
-            app: expect.objectContaining({ releaseStage: 'production', version: '1.2.3', type: 'worker' }),
+            app: expect.objectContaining({ releaseStage: 'production', version: '1.2.3', type: 'worker', codeBundleId: '691f4728-4bf5-4da3-a954-ea9a10fa17d2' }),
             breadcrumbs: [],
             device: expect.objectContaining({ manufacturer: 'Google', model: 'Pixel 4', modelNumber: undefined, osName: 'android', totalMemory: undefined }),
             errors: expect.arrayContaining([

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -1,6 +1,6 @@
 import { BugsnagStatic, Config, Client } from '@bugsnag/core'
 
-type ExpoConfig = Partial<Config>
+type ExpoConfig = Partial<Config> & { codeBundleId?: string }
 interface ExpoBugsnagStatic extends BugsnagStatic {
   start(apiKeyOrOpts?: string | ExpoConfig): Client
   isStarted(): boolean

--- a/packages/expo/types/bugsnag.d.ts
+++ b/packages/expo/types/bugsnag.d.ts
@@ -1,6 +1,9 @@
 import { BugsnagStatic, Config, Client } from '@bugsnag/core'
 
-type ExpoConfig = Partial<Config> & { codeBundleId?: string }
+interface ExpoConfig extends Partial<Config> { 
+  codeBundleId?: string 
+}
+
 interface ExpoBugsnagStatic extends BugsnagStatic {
   start(apiKeyOrOpts?: string | ExpoConfig): Client
   isStarted(): boolean

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -31,6 +31,9 @@ module.exports = {
     }
 
     client.addOnSession(session => {
+      if (client._config.codeBundleId) {
+        session.app.codeBundleId = client._config.codeBundleId
+      }
       if (versionCode) {
         session.app.versionCode = versionCode
       } else if (bundleVersion) {
@@ -47,6 +50,10 @@ module.exports = {
 
       if (inForeground) {
         event.app.durationInForeground = now - lastEnteredForeground
+      }
+
+      if (client._config.codeBundleId) {
+        event.app.codeBundleId = client._config.codeBundleId
       }
 
       event.addMetadata('app', { nativeBundleVersion, nativeVersionCode, bundleVersion, versionCode })

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -33,15 +33,8 @@ module.exports = {
     client.addOnSession(session => {
       if (versionCode) {
         session.app.versionCode = versionCode
-      }
-      else if (bundleVersion) {
+      } else if (bundleVersion) {
         session.app.bundleVersion = bundleVersion
-      }
-      
-      if (Constants.manifest?.revisionId) {
-        session.app.codeBundleId = Constants.manifest.revisionId
-      } else if (Constants.manifest2?.extra?.expoClient?.revisionId) {
-        session.app.codeBundleId = Constants.manifest2.extra.expoClient.revisionId
       }
     })
 
@@ -57,12 +50,6 @@ module.exports = {
       }
 
       event.addMetadata('app', { nativeBundleVersion, nativeVersionCode, bundleVersion, versionCode })
-
-      if (Constants.manifest?.revisionId) {
-        event.app.codeBundleId = Constants.manifest.revisionId
-      } else if (Constants.manifest2?.extra?.expoClient?.revisionId) {
-        event.app.codeBundleId = Constants.manifest2.extra.expoClient.revisionId
-      }
     }, true)
   }
 }

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -55,10 +55,8 @@ module.exports = {
         event.app.codeBundleId = client._config.codeBundleId
       }
 
-      if (versionCode) {
-        event.app.versionCode = versionCode
-      } else if (bundleVersion) {
-        event.app.bundleVersion = bundleVersion
+      event.app.versionCode = versionCode
+      event.app.bundleVersion = bundleVersion
       }
 
       event.addMetadata('app', { nativeBundleVersion, nativeVersionCode })

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -34,6 +34,7 @@ module.exports = {
       if (client._config.codeBundleId) {
         session.app.codeBundleId = client._config.codeBundleId
       }
+
       if (versionCode) {
         session.app.versionCode = versionCode
       } else if (bundleVersion) {
@@ -56,7 +57,13 @@ module.exports = {
         event.app.codeBundleId = client._config.codeBundleId
       }
 
-      event.addMetadata('app', { nativeBundleVersion, nativeVersionCode, bundleVersion, versionCode })
+      if (versionCode) {
+        event.app.versionCode = versionCode
+      } else if (bundleVersion) {
+        event.app.bundleVersion = bundleVersion
+      }
+
+      event.addMetadata('app', { nativeBundleVersion, nativeVersionCode })
     }, true)
   }
 }

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -16,27 +16,22 @@ module.exports = {
       lastState = newState
     })
 
-    let nativeBundleVersion, nativeVersionCode, bundleVersion, versionCode
+    let bundleVersion, versionCode
 
     if (Constants.appOwnership !== 'expo') {
       if (Constants.platform.ios) {
-        nativeBundleVersion = Application.nativeBuildVersion
         bundleVersion = Application.nativeBuildVersion
-      }
-
-      if (Constants.platform.android) {
-        nativeVersionCode = Application.nativeBuildVersion
+      } else if (Constants.platform.android) {
         versionCode = Application.nativeBuildVersion
       }
     }
 
     client.addOnSession(session => {
-      if (client._config.codeBundleId) {
-        session.app.codeBundleId = client._config.codeBundleId
-      }
-
       session.app.versionCode = versionCode
       session.app.bundleVersion = bundleVersion
+
+      if (client._config.codeBundleId) {
+        session.app.codeBundleId = client._config.codeBundleId
       }
     })
 
@@ -57,9 +52,8 @@ module.exports = {
 
       event.app.versionCode = versionCode
       event.app.bundleVersion = bundleVersion
-      }
 
-      event.addMetadata('app', { nativeBundleVersion, nativeVersionCode })
+      event.addMetadata('app', { nativeBundleVersion: bundleVersion, nativeVersionCode: versionCode })
     }, true)
   }
 }

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -35,10 +35,8 @@ module.exports = {
         session.app.codeBundleId = client._config.codeBundleId
       }
 
-      if (versionCode) {
-        session.app.versionCode = versionCode
-      } else if (bundleVersion) {
-        session.app.bundleVersion = bundleVersion
+      session.app.versionCode = versionCode
+      session.app.bundleVersion = bundleVersion
       }
     })
 

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -31,6 +31,13 @@ module.exports = {
     }
 
     client.addOnSession(session => {
+      if (versionCode) {
+        session.app.versionCode = versionCode
+      }
+      else if (bundleVersion) {
+        session.app.bundleVersion = bundleVersion
+      }
+      
       if (Constants.manifest?.revisionId) {
         session.app.codeBundleId = Constants.manifest.revisionId
       } else if (Constants.manifest2?.extra?.expoClient?.revisionId) {

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -16,15 +16,17 @@ module.exports = {
       lastState = newState
     })
 
-    let nativeBundleVersion, nativeVersionCode
+    let nativeBundleVersion, nativeVersionCode, bundleVersion, versionCode
 
-    if (Constants.appOwnership === 'standalone') {
+    if (Constants.appOwnership !== 'expo') {
       if (Constants.platform.ios) {
         nativeBundleVersion = Application.nativeBuildVersion
+        bundleVersion = Application.nativeBuildVersion
       }
 
       if (Constants.platform.android) {
         nativeVersionCode = Application.nativeBuildVersion
+        versionCode = Application.nativeBuildVersion
       }
     }
 
@@ -47,7 +49,7 @@ module.exports = {
         event.app.durationInForeground = now - lastEnteredForeground
       }
 
-      event.addMetadata('app', { nativeBundleVersion, nativeVersionCode })
+      event.addMetadata('app', { nativeBundleVersion, nativeVersionCode, bundleVersion, versionCode })
 
       if (Constants.manifest?.revisionId) {
         event.app.codeBundleId = Constants.manifest.revisionId

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -221,7 +221,6 @@ describe('plugin: expo app', () => {
   })
 
   it('should not record codeBundleId if not configured', done => {
-
     jest.doMock('expo-application', () => ({}))
     jest.doMock('expo-constants', () => ({
       default: {

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -12,7 +12,7 @@ describe('plugin: expo app', () => {
     jest.resetModules()
   })
 
-  it('should should use revisionId if defined (all platforms)', done => {
+  it('should use revisionId if defined (all platforms)', done => {
     const VERSION = '1.0.0'
     const REVISION_ID = '1.0.0-r132432'
 
@@ -40,7 +40,7 @@ describe('plugin: expo app', () => {
     c.notify(new Error('flip'))
   })
 
-  it('should record nativeVersionCode on android', done => {
+  it('should record nativeVersionCode and versionCode on android', done => {
     const VERSION_CODE = '1.0'
 
     jest.doMock('expo-application', () => ({ nativeBuildVersion: VERSION_CODE }))
@@ -50,7 +50,7 @@ describe('plugin: expo app', () => {
           android: {}
         },
         manifest: { version: '1.0.0' },
-        appOwnership: 'standalone'
+        appOwnership: null
       }
     }))
 
@@ -63,6 +63,7 @@ describe('plugin: expo app', () => {
         const r = JSON.parse(JSON.stringify(payload))
         expect(r).toBeTruthy()
         expect(r.events[0].metaData.app.nativeVersionCode).toBe(VERSION_CODE)
+        expect(r.events[0].metaData.app.versionCode).toBe(VERSION_CODE)
         done()
       },
       sendSession: () => {}
@@ -70,7 +71,7 @@ describe('plugin: expo app', () => {
     c.notify(new Error('flip'))
   })
 
-  it('should record nativeBundleVersion on ios', done => {
+  it('should record nativeBundleVersion and bundleVersion on ios', done => {
     const BUNDLE_VERSION = '1.0'
 
     jest.doMock('expo-application', () => ({ nativeBuildVersion: BUNDLE_VERSION }))
@@ -80,7 +81,7 @@ describe('plugin: expo app', () => {
           ios: {}
         },
         manifest: { version: '1.0.0' },
-        appOwnership: 'standalone'
+        appOwnership: null
       }
     }))
 
@@ -93,6 +94,7 @@ describe('plugin: expo app', () => {
         const r = JSON.parse(JSON.stringify(payload))
         expect(r).toBeTruthy()
         expect(r.events[0].metaData.app.nativeBundleVersion).toBe(BUNDLE_VERSION)
+        expect(r.events[0].metaData.app.bundleVersion).toBe(BUNDLE_VERSION)
         done()
       },
       sendSession: () => {}

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -57,6 +57,11 @@ describe('plugin: expo app', () => {
     const plugin = require('..')
 
     const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
+    c._sessionDelegate = {
+      startSession: (client, session) => {
+        client._delivery.sendSession(session)
+      }
+    }
 
     c._setDelivery(client => ({
       sendEvent: (payload) => {
@@ -66,8 +71,12 @@ describe('plugin: expo app', () => {
         expect(r.events[0].metaData.app.versionCode).toBe(VERSION_CODE)
         done()
       },
-      sendSession: () => {}
+      sendSession: (session) => {
+        expect(session).toBeTruthy()
+        expect(session.app.versionCode).toBe(VERSION_CODE)
+      }
     }))
+    c.startSession()
     c.notify(new Error('flip'))
   })
 
@@ -88,6 +97,12 @@ describe('plugin: expo app', () => {
     const plugin = require('..')
 
     const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
+    
+    c._sessionDelegate = {
+      startSession: (client, session) => {
+        client._delivery.sendSession(session)
+      }
+    }
 
     c._setDelivery(client => ({
       sendEvent: (payload) => {
@@ -97,8 +112,12 @@ describe('plugin: expo app', () => {
         expect(r.events[0].metaData.app.bundleVersion).toBe(BUNDLE_VERSION)
         done()
       },
-      sendSession: () => {}
+      sendSession: (session) => {
+        expect(session).toBeTruthy()
+        expect(session.app.bundleVersion).toBe(BUNDLE_VERSION)
+      }
     }))
+    c.startSession()
     c.notify(new Error('flip'))
   })
 

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -41,7 +41,7 @@ describe('plugin: expo app', () => {
         const r = JSON.parse(JSON.stringify(payload))
         expect(r).toBeTruthy()
         expect(r.events[0].metaData.app.nativeVersionCode).toBe(VERSION_CODE)
-        expect(r.events[0].metaData.app.versionCode).toBe(VERSION_CODE)
+        expect(r.events[0].app.versionCode).toBe(VERSION_CODE)
         done()
       },
       sendSession: (session) => {
@@ -82,7 +82,7 @@ describe('plugin: expo app', () => {
         const r = JSON.parse(JSON.stringify(payload))
         expect(r).toBeTruthy()
         expect(r.events[0].metaData.app.nativeBundleVersion).toBe(BUNDLE_VERSION)
-        expect(r.events[0].metaData.app.bundleVersion).toBe(BUNDLE_VERSION)
+        expect(r.events[0].app.bundleVersion).toBe(BUNDLE_VERSION)
         done()
       },
       sendSession: (session) => {

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -12,34 +12,6 @@ describe('plugin: expo app', () => {
     jest.resetModules()
   })
 
-  it('should use revisionId if defined (all platforms)', done => {
-    const VERSION = '1.0.0'
-    const REVISION_ID = '1.0.0-r132432'
-
-    jest.doMock('expo-application', () => ({}))
-    jest.doMock('expo-constants', () => ({
-      default: {
-        platform: {},
-        manifest: { version: VERSION, revisionId: REVISION_ID }
-      }
-    }))
-
-    const plugin = require('..')
-
-    const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
-
-    c._setDelivery(client => ({
-      sendEvent: (payload) => {
-        const r = JSON.parse(JSON.stringify(payload))
-        expect(r).toBeTruthy()
-        expect(r.events[0].app.codeBundleId).toBe(REVISION_ID)
-        done()
-      },
-      sendSession: () => {}
-    }))
-    c.notify(new Error('flip'))
-  })
-
   it('should record nativeVersionCode and versionCode on android', done => {
     const VERSION_CODE = '1.0'
 
@@ -97,7 +69,7 @@ describe('plugin: expo app', () => {
     const plugin = require('..')
 
     const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
-    
+
     c._sessionDelegate = {
       startSession: (client, session) => {
         client._delivery.sendSession(session)

--- a/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-expo-xcode.sh
+++ b/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-expo-xcode.sh
@@ -4,6 +4,7 @@ set -o errexit
 
 INFO_PLIST=$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH
 APP_VERSION=$(/usr/libexec/PlistBuddy -c "print :CFBundleShortVersionString" "$INFO_PLIST")
+BUNDLE_VERSION=$(/usr/libexec/PlistBuddy -c "print :CFBundleVersion" "$INFO_PLIST")
 API_KEY="$BUGSNAG_API_KEY"
 
 # in RN 0.64+ the JS bundle is in this location
@@ -41,6 +42,7 @@ PROJECT_ROOT=${PWD%\/ios}
 ARGS=(
     "--api-key" "$API_KEY"
     "--app-version" "$APP_VERSION"
+    "--app-bundle-version" "$BUNDLE_VERSION"
     "--bundle" "$BUNDLE_FILE"
     "--platform" "ios"
     "--source-map" "$SOURCE_MAP"

--- a/test/features/app.feature
+++ b/test/features/app.feature
@@ -15,7 +15,16 @@ Scenario: App data is included by default
   And the event "app.durationInForeground" is not null
   And the event "app.inForeground" is true
   And the event "app.type" equals the current OS name
+  And the event "app.codeBundleId" equals "691f4728-4bf5-4da3-a954-ea9a10fa17d2"
   And the error Bugsnag-Integrity header is valid
+  # Parameter not present on iOS devices
+  And the event "app.versionCode" equals the platform-dependent string:
+    | android | 1     |
+    | ios     | @skip |
+  # Parameter not present on Android devices
+  And the event "app.bundleVersion" equals the platform-dependent string:
+    | android | @skip |
+    | ios     | 1     |
 
 Scenario: App data can be modified by a callback
   Given the element "enhancedAppButton" is present
@@ -27,4 +36,5 @@ Scenario: App data can be modified by a callback
   And the event "app.durationInForeground" is not null
   And the event "app.inForeground" is true
   And the event "app.type" equals "custom app type"
+  And the event "app.codeBundleId" equals "1.2.3"
   And the error Bugsnag-Integrity header is valid

--- a/test/features/app.feature
+++ b/test/features/app.feature
@@ -20,10 +20,10 @@ Scenario: App data is included by default
   # Parameter not present on iOS devices
   And the event "app.versionCode" equals the platform-dependent string:
     | android | 1     |
-    | ios     | @skip |
+    | ios     | @null |
   # Parameter not present on Android devices
   And the event "app.bundleVersion" equals the platform-dependent string:
-    | android | @skip |
+    | android | @null |
     | ios     | 1     |
 
 Scenario: App data can be modified by a callback

--- a/test/features/fixtures/test-app/app.json
+++ b/test/features/fixtures/test-app/app.json
@@ -21,7 +21,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.bugsnag.expo.testfixture",
-      "buildNumber": 1
+      "buildNumber": "1"
     },
     "android": {
       "package": "com.bugsnag.expo.testfixture",

--- a/test/features/fixtures/test-app/app.json
+++ b/test/features/fixtures/test-app/app.json
@@ -20,14 +20,16 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.bugsnag.expo.testfixture"
+      "bundleIdentifier": "com.bugsnag.expo.testfixture",
+      "buildNumber": 1
     },
     "android": {
       "package": "com.bugsnag.expo.testfixture",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
-      }
+      },
+      "versionCode": 1
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/test/features/fixtures/test-app/app/app.js
+++ b/test/features/fixtures/test-app/app/app.js
@@ -1,17 +1,29 @@
 import React, { Component } from 'react'
 import { View, Button } from 'react-native'
-import { bugsnagClient } from './bugsnag'
+import { endpoints } from './bugsnag'
+import Bugsnag from '@bugsnag/expo'
 
 export default class AppFeature extends Component {
   defaultApp = () => {
+    bugsnagClient = Bugsnag.createClient({
+      endpoints: endpoints,
+      autoTrackSessions: false,
+      codeBundleId: '691f4728-4bf5-4da3-a954-ea9a10fa17d2'
+    })
     bugsnagClient.notify(new Error('HandledError'))
   }
 
   enhancedApp = () => {
+    bugsnagClient = Bugsnag.createClient({
+      endpoints: endpoints,
+      autoTrackSessions: false,
+      codeBundleId: '691f4728-4bf5-4da3-a954-ea9a10fa17d2'
+    })
     bugsnagClient.notify(new Error('HandledError'), event => {
-      event.app.releaseStage = 'enhancedReleaseStage',
+      event.app.releaseStage = 'enhancedReleaseStage'
       event.app.version = '5.5.5'
       event.app.type = 'custom app type'
+      event.app.codeBundleId = '1.2.3'
     })
   }
 


### PR DESCRIPTION
## Goal

To fix a source map matching bug on Android when using EAS Build, and improve support for EAS Update by exposing the `codeBundleId` config option

## Design

`app.versionCode` (Android) and `app.bundleVersion` (iOS) metadata has been added to both events and sessions for standalone apps using `Application.nativeBuildVersion` from `expo-application`.

This fixes a source map matching bug for EAS Build on Android which occurs because the native build specifies `versionCode` on the source map upload. For consistency, automatic source map uploads on iOS have also been updated to specify a `bundleVersion`.  

This also fixes a bug which means that the existing `nativeVersionCode` and `nativeBundleVersion` metadata is not set when using EAS Build due to [`Constants.appOwnership` now returning null for standalone apps](https://docs.expo.dev/build-reference/migrating/#constantsappownership-will-be-null-in-the-resulting-standalone-app). These metadata properties will be removed in the next major version of the notifier.

 `codeBundleId` is now available as a configuration option in order to improve support for matching source maps when using EAS Update. This allows developers to use `updateGroup` ID provided by EAS Update to configure a `codeBundleId` both in the notifier config and for manual source map uploads.

## Changeset

- `app.VersionCode` and `app.bundleVersion` added to sessions and events for standalone Android and iOS apps respectively
- EAS sourcemap plugin now sets `--app-bundle-version` parameter for iOS uploads using the `CFBundleVersion` value from `Info.plist`
- `codeBundleId` config option added to notifier
- Removed code for automatically setting `codeBundleId` based on `revisionId` as this is no longer provided in EAS Update

## Testing

- Unit tests have been updated to check `versionCode` and `bundleVersion` in sessions and events, and new unit tests have been added for `codeBundleId` config.
- e2e tests updated to check `versionCode` and `bundleVersion` on Android and iOS respectively
- Manual testing:
  - Manually tested that `versionCode` and `bundleVersion` is set for standalone apps only, and that automatic source map uploads are correctly matched to events on both Android and iOS
  - manually tested that `codeBundleId` config option can be used to match manual sourcemap uploads to events from EAS Updates