### PR TITLE
resolve expo-modules-core to 1.0.4

### DIFF
--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@react-native-community/netinfo": "9.3.5",
-    "expo": "~47.0.3",
+    "expo": "47.0.9",
     "expo-application": "~5.0.1",
     "expo-constants": "~14.0.2",
     "expo-crypto": "~12.0.0",

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@react-native-community/netinfo": "9.3.5",
-    "expo": "47.0.9",
+    "expo": "~47.0.3",
     "expo-application": "~5.0.1",
     "expo-constants": "~14.0.2",
     "expo-crypto": "~12.0.0",
@@ -20,6 +20,9 @@
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
     "react-native": "0.70.5"
+  },
+  "resolutions": {
+    "expo-modules-core": "1.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3"


### PR DESCRIPTION
## Goal

To ensure test fixture builds and testing can complete. Version can be unpinned once [the expo issue](https://github.com/expo/expo/issues/20679) has been resolved