### PR TITLE
Restrict the bugsnag gradle plugin dependency to v7.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - (bugsnag-expo-cli) Fix issue with automated installation when using app.config.js [#72](https://github.com/bugsnag/bugsnag-expo/pull/72)
 - (expo) Add promise v8 as a peer dependency [#77](https://github.com/bugsnag/bugsnag-expo/pull/77)
+- (plugin-expo-eas-sourcemaps) Restrict Bugsnag Android Gradle Plugin dependency to v7 [#101](https://github.com/bugsnag/bugsnag-expo/pull/101)
 
 ## v45.1.2 (2022-08-21)
 

--- a/packages/plugin-expo-eas-sourcemaps/src/android.js
+++ b/packages/plugin-expo-eas-sourcemaps/src/android.js
@@ -52,7 +52,7 @@ function injectDependencies (script) {
             mavenCentral()
         }
         dependencies {
-            classpath 'com.bugsnag:bugsnag-android-gradle-plugin:[7.3.0,)'
+            classpath 'com.bugsnag:bugsnag-android-gradle-plugin:7.+'
         }
     }
 


### PR DESCRIPTION
## Goal

Restrict the Bugsnag Android Gradle Plugin dependency in the EAS sourcemap plugin to v7.x

Fixes an issue where the EAS sourcemap plugin was incorrectly pulling in v8 of the Bugsnag Android Gradle Plugin, causing build errors on Android.

## Testing
Manually tested