### PR TITLE
Restrict bugsnag gradle plugin dependency to v7 (v47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD
+
+(plugin-expo-eas-sourcemaps) Restrict Bugsnag Android Gradle Plugin dependency to v7 [#104](https://github.com/bugsnag/bugsnag-expo/pull/104)
+
 ## v47.1.0 (2023-01-09)
 
 ### Fixed

--- a/packages/plugin-expo-eas-sourcemaps/src/android.js
+++ b/packages/plugin-expo-eas-sourcemaps/src/android.js
@@ -52,7 +52,7 @@ function injectDependencies (script) {
             mavenCentral()
         }
         dependencies {
-            classpath 'com.bugsnag:bugsnag-android-gradle-plugin:[7.3.0,)'
+            classpath 'com.bugsnag:bugsnag-android-gradle-plugin:7.+'
         }
     }
 


### PR DESCRIPTION
## Goal

Restrict the Bugsnag Android Gradle Plugin dependency in the EAS sourcemap plugin to v7.x

Fixes an issue where the EAS sourcemap plugin was incorrectly pulling in v8 of the Bugsnag Android Gradle Plugin, causing build errors on Android.

## Testing
Relied on CI