### PR TITLE
[PLAT-9758] Install a sourcemap plugin version that matches the SDK version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (bugsnag-expo-cli) CLI tool now installs a sourcemap plugin version that matches the Expo SDK version [#111](https://github.com/bugsnag/bugsnag-expo/pull/111)
+
 ## v47.1.1 (2023-03-02)
 
 (plugin-expo-eas-sourcemaps) Restrict Bugsnag Android Gradle Plugin dependency to v7 [#104](https://github.com/bugsnag/bugsnag-expo/pull/104)

--- a/packages/expo-cli/commands/upload-sourcemaps.js
+++ b/packages/expo-cli/commands/upload-sourcemaps.js
@@ -2,7 +2,7 @@ const prompts = require('prompts')
 const addPlugin = require('../lib/configure-plugin')
 const installPlugin = require('../lib/install-plugin')
 const { onCancel, getDependencies } = require('../lib/utils')
-const { isEarlierVersionThan } = require('../lib/version-information')
+const { isEarlierVersionThan, getBugsnagVersionForExpoVersion } = require('../lib/version-information')
 const { blue, yellow } = require('kleur')
 
 const PLUGIN_NAME = '@bugsnag/plugin-expo-eas-sourcemaps'
@@ -38,7 +38,12 @@ module.exports = async (argv, globalOpts) => {
         yarn: globalOpts.yarn
       }
 
-      await installPlugin(projectRoot, options)
+      // install a plugin version that matches the SDK version, i.e. SDK 48 -> @bugsnag/plugin-expo-eas-sourcemaps@^48.0.0
+      // if there is no suitable bugsnag version we haven't yet released support for this Expo version, so install the latest
+      const versionInformation = getBugsnagVersionForExpoVersion(installedExpoVersion)
+      const pluginVersion = versionInformation ? versionInformation.bugsnagVersion : 'latest'
+
+      await installPlugin(pluginVersion, projectRoot, options)
     }
 
     console.log(blue('> Inserting EAS plugin into app.json'))

--- a/packages/expo-cli/lib/install.js
+++ b/packages/expo-cli/lib/install.js
@@ -1,8 +1,8 @@
 const { spawn } = require('child_process')
-const { DEPENDENCIES } = require('./utils')
+const { DEPENDENCIES, resolvePackageName } = require('./utils')
 
 function resolveCommand (version, options) {
-  const command = ['install', resolvePackageName(version)].concat(DEPENDENCIES)
+  const command = ['install', resolvePackageName('@bugsnag/expo', version)].concat(DEPENDENCIES)
 
   if (options.npm) {
     command.push('--npm')
@@ -13,14 +13,6 @@ function resolveCommand (version, options) {
   }
 
   return command
-}
-
-function resolvePackageName (version) {
-  if (version === 'latest') {
-    return '@bugsnag/expo'
-  }
-
-  return `@bugsnag/expo@${version}`
 }
 
 module.exports = (version, projectRoot, options) => {

--- a/packages/expo-cli/lib/test/install-plugin.test.js
+++ b/packages/expo-cli/lib/test/install-plugin.test.js
@@ -1,6 +1,4 @@
 const withFixture = require('./lib/with-fixture')
-const { EventEmitter } = require('events')
-const { Readable } = require('stream')
 
 describe('expo-cli: upload-sourcemaps install plugin', () => {
   beforeEach(() => {
@@ -9,187 +7,167 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
 
   it('should work on a fresh project', async () => {
     await withFixture('blank-00', async (projectRoot) => {
-      const spawn = (cmd, args, opts) => {
-        expect(cmd).toBe('expo')
-        expect(args).toEqual(['install', '@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
-        expect(opts).toEqual({ cwd: projectRoot })
-
-        const proc = new EventEmitter()
-        proc.stdout = new Readable({
-          read () {}
-        })
-        proc.stderr = new Readable({
-          read () {}
-        })
-        setTimeout(() => proc.emit('close', 0), 10)
-        return proc
+      const packageManager = {
+        addDevAsync: async (packages) => {
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          return Promise.resolve()
+        }
       }
 
-      jest.doMock('child_process', () => ({ spawn }))
+      const createForProject = (root, options) => {
+        expect(root).toEqual(projectRoot)
+        expect(options).toEqual({ npm: false, yarn: false })
+        return packageManager
+      }
+
+      jest.doMock('@expo/package-manager', () => ({ createForProject }))
       const installPlugin = require('../install-plugin')
 
-      const msg = await installPlugin(projectRoot, { npm: false, yarn: false })
+      const msg = await installPlugin('latest', projectRoot, { npm: false, yarn: false })
       expect(msg).toBe(undefined)
     })
   })
 
   it('should allow forcing install with NPM', async () => {
     await withFixture('blank-00', async (projectRoot) => {
-      const spawn = (cmd, args, opts) => {
-        expect(cmd).toBe('expo')
-        expect(args).toEqual([
-          'install',
-          '@bugsnag/plugin-expo-eas-sourcemaps',
-          '@bugsnag/source-maps',
-          '--npm',
-          '--',
-          '--save-dev'
-        ])
-        expect(opts).toEqual({ cwd: projectRoot })
-
-        const proc = new EventEmitter()
-        proc.stdout = new Readable({
-          read () {}
-        })
-        proc.stderr = new Readable({
-          read () {}
-        })
-        setTimeout(() => proc.emit('close', 0), 10)
-        return proc
+      const packageManager = {
+        addDevAsync: async (packages) => {
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          return Promise.resolve()
+        }
       }
 
-      jest.doMock('child_process', () => ({ spawn }))
+      const createForProject = (root, options) => {
+        expect(root).toEqual(projectRoot)
+        expect(options).toEqual({ npm: true })
+        return packageManager
+      }
+
+      jest.doMock('@expo/package-manager', () => ({ createForProject }))
       const installPlugin = require('../install-plugin')
 
-      const msg = await installPlugin(projectRoot, { npm: true })
+      const msg = await installPlugin('latest', projectRoot, { npm: true })
       expect(msg).toBe(undefined)
     })
   })
 
   it('should allow forcing install with Yarn', async () => {
     await withFixture('blank-00', async (projectRoot) => {
-      const spawn = (cmd, args, opts) => {
-        expect(cmd).toBe('expo')
-        expect(args).toEqual([
-          'install',
-          '@bugsnag/plugin-expo-eas-sourcemaps',
-          '@bugsnag/source-maps',
-          '--yarn',
-          '--',
-          '--dev'
-        ])
-        expect(opts).toEqual({ cwd: projectRoot })
-
-        const proc = new EventEmitter()
-        proc.stdout = new Readable({
-          read () {}
-        })
-        proc.stderr = new Readable({
-          read () {}
-        })
-        setTimeout(() => proc.emit('close', 0), 10)
-        return proc
+      const packageManager = {
+        addDevAsync: async (packages) => {
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          return Promise.resolve()
+        }
       }
 
-      jest.doMock('child_process', () => ({ spawn }))
+      const createForProject = (root, options) => {
+        expect(root).toEqual(projectRoot)
+        expect(options).toEqual({ yarn: true })
+        return packageManager
+      }
+
+      jest.doMock('@expo/package-manager', () => ({ createForProject }))
       const installPlugin = require('../install-plugin')
 
-      const msg = await installPlugin(projectRoot, { yarn: true })
+      const msg = await installPlugin('latest', projectRoot, { yarn: true })
       expect(msg).toBe(undefined)
     })
   })
 
-  // highly doubt this will ever fail, assuming one of npm or yarn will take precedence over the other
-  // if test begins to fail, might need to consider additonal error messages
+  // not sure if this test is really necessary any more?
   it('should allow forcing install with both NPM and Yarn', async () => {
     await withFixture('blank-00', async (projectRoot) => {
-      const spawn = (cmd, args, opts) => {
-        expect(cmd).toBe('expo')
-        expect(args).toEqual([
-          'install',
-          '@bugsnag/plugin-expo-eas-sourcemaps',
-          '@bugsnag/source-maps',
-          '--npm',
-          '--',
-          '--save-dev',
-          '--yarn',
-          '--',
-          '--dev'
-        ])
-
-        expect(opts).toEqual({ cwd: projectRoot })
-
-        const proc = new EventEmitter()
-        proc.stdout = new Readable({
-          read () {}
-        })
-        proc.stderr = new Readable({
-          read () {}
-        })
-        setTimeout(() => proc.emit('close', 0), 10)
-        return proc
+      const packageManager = {
+        addDevAsync: async (packages) => {
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          return Promise.resolve()
+        }
       }
 
-      jest.doMock('child_process', () => ({ spawn }))
+      const createForProject = (root, options) => {
+        expect(root).toEqual(projectRoot)
+        expect(options).toEqual({ npm: true, yarn: true })
+        return packageManager
+      }
+
+      jest.doMock('@expo/package-manager', () => ({ createForProject }))
       const installPlugin = require('../install-plugin')
 
-      const msg = await installPlugin(projectRoot, { npm: true, yarn: true })
+      const msg = await installPlugin('latest', projectRoot, { npm: true, yarn: true })
       expect(msg).toBe(undefined)
     })
   })
 
-  it('should add stderr/stdout output onto error if there is one (non-zero exit code)', async () => {
-    const spawn = (cmd, args, opts) => {
-      const proc = new EventEmitter()
-      proc.stdout = new Readable({
-        read () {
-          this.push('some data on stdout')
-          this.push(null)
+  it('should allow specifying a package version', async () => {
+    await withFixture('blank-00', async (projectRoot) => {
+      const packageManager = {
+        addDevAsync: async (packages) => {
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps@^48.0.0', '@bugsnag/source-maps'])
+          return Promise.resolve()
         }
-      })
-      proc.stderr = new Readable({
-        read () {
-          this.push('some data on stderr')
-          this.push(null)
+      }
+
+      const createForProject = (root, options) => {
+        expect(root).toEqual(projectRoot)
+        expect(options).toEqual({ yarn: false })
+        return packageManager
+      }
+
+      jest.doMock('@expo/package-manager', () => ({ createForProject }))
+      const installPlugin = require('../install-plugin')
+      const msg = await installPlugin('^48.0.0', projectRoot, { yarn: false })
+      expect(msg).toBe(undefined)
+    })
+  })
+
+  it('should throw an error if the command does', async () => {
+    await withFixture('blank-00', async (projectRoot) => {
+      const packageManager = {
+        addDevAsync: async (packages) => {
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          return Promise.reject(new Error('floop'))
         }
-      })
-      setTimeout(() => proc.emit('close', 1), 10)
-      return proc
+      }
+
+      const createForProject = (root, options) => {
+        expect(root).toEqual(projectRoot)
+        expect(options).toEqual({ yarn: false })
+        return packageManager
+      }
+
+      jest.doMock('@expo/package-manager', () => ({ createForProject }))
+      const installPlugin = require('../install-plugin')
+      await expect(installPlugin('latest', projectRoot, { yarn: false })).rejects.toThrow(/floop/)
+    })
+  })
+
+  it('should add stderr/stdout output onto error if there is one', async () => {
+    const packageManager = {
+      addDevAsync: async (packages) => {
+        expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+        const error = new Error('floop')
+        error.stdout = 'some data on stdout'
+        error.stderr = 'some data on stderr'
+        return Promise.reject(error)
+      }
     }
 
-    jest.doMock('child_process', () => ({ spawn }))
+    const createForProject = (root, options) => {
+      return packageManager
+    }
+
+    jest.doMock('@expo/package-manager', () => ({ createForProject }))
     const installPlugin = require('../install-plugin')
 
     await withFixture('blank-00', async (projectRoot) => {
-      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/plugin-expo-eas-sourcemaps @bugsnag/source-maps"
+      const expected = `floop
 stdout:
 some data on stdout
 
 stderr:
 some data on stderr`
 
-      await expect(installPlugin(projectRoot, { npm: false })).rejects.toThrow(expected)
-    })
-  })
-
-  it('should throw an error if the command does', async () => {
-    const spawn = (cmd, args, opts) => {
-      const proc = new EventEmitter()
-      proc.stdout = new Readable({
-        read () {}
-      })
-      proc.stderr = new Readable({
-        read () {}
-      })
-      setTimeout(() => proc.emit('error', new Error('floop')), 10)
-      return proc
-    }
-
-    jest.doMock('child_process', () => ({ spawn }))
-    const installPlugin = require('../install-plugin')
-
-    await withFixture('blank-00', async (projectRoot) => {
-      await expect(installPlugin(projectRoot, { yarn: false })).rejects.toThrow(/floop/)
+      await expect(installPlugin('latest', projectRoot, { npm: false })).rejects.toThrow(expected)
     })
   })
 })

--- a/packages/expo-cli/lib/utils.js
+++ b/packages/expo-cli/lib/utils.js
@@ -22,9 +22,18 @@ async function getDependencies (directory) {
   return cachedDependencies.get(directory)
 }
 
+function resolvePackageName (packageName, version) {
+  if (version === 'latest') {
+    return packageName
+  }
+
+  return `${packageName}@${version}`
+}
+
 module.exports = {
   onCancel: () => process.exit(),
   getDependencies,
+  resolvePackageName,
   DEPENDENCIES: [
     '@react-native-community/netinfo',
     'expo-application',

--- a/packages/expo-cli/package.json
+++ b/packages/expo-cli/package.json
@@ -11,6 +11,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
+    "@expo/package-manager": "^1.0.1",
     "command-line-args": "^5.0.2",
     "kleur": "^3.0.2",
     "prompts": "^2.0.4",


### PR DESCRIPTION
## Goal

Updates `bugsnag-expo-cli` to install a version of the sourcemap plugin that matches the project's Expo SDK version (and by extension Bugsnag version).

This makes it easier to introduce breaking changes to the sourcemap plugin by reducing the likelihood of newer versions being inadvertently installed into projects running older SDK versions.

## Design

The CLI now uses `@expo/package-manager` to install the sourcemap plugin instead of running `expo install` - this is due to an issue with `expo install` that means versioned installs are always saved to the project's main `dependencies` list and not to `devDependencies`

## Testing

- Manually tested installation using the CLI
- Updated unit tests