### PR TITLE
EAS sourcemap plugin fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- (plugin-expo-eas-sourcemaps) Reinstate API key in Android manifest [#117](https://github.com/bugsnag/bugsnag-expo/pull/117)
+- (plugin-expo-eas-sourcemaps) Support dynamic configuration files in EAS Build lifecycle hook [#117](https://github.com/bugsnag/bugsnag-expo/pull/117)
+
 ## v48.0.0 (2023-03-07)
 
 This release adds support for expo 48

--- a/packages/plugin-expo-eas-sourcemaps/index.js
+++ b/packages/plugin-expo-eas-sourcemaps/index.js
@@ -1,3 +1,4 @@
+const { withAndroidPlugin } = require('./src/android')
 const { withIosPlugin } = require('./src/ios')
 
 const { createRunOncePlugin, WarningAggregator } = require('@expo/config-plugins')
@@ -6,6 +7,7 @@ const pkg = require('./package.json')
 
 function withSourcemapUploads (config) {
   const onPremConfig = getOnPremConfig(config)
+  config = withAndroidPlugin(config, onPremConfig)
   config = withIosPlugin(config, onPremConfig)
   return config
 }

--- a/packages/plugin-expo-eas-sourcemaps/lib/eas-build-on-success.js
+++ b/packages/plugin-expo-eas-sourcemaps/lib/eas-build-on-success.js
@@ -3,6 +3,7 @@
 const { access } = require('fs').promises
 const { reactNative } = require('@bugsnag/source-maps')
 const { exit } = require('process')
+const { getConfig } = require('@expo/config')
 
 const PROJECT_ROOT = process.cwd()
 
@@ -29,15 +30,15 @@ const uploadSourceMaps = async () => {
 
   let appConfig, apiKey
   try {
-    appConfig = require(`${PROJECT_ROOT}/app.json`)
-    apiKey = appConfig?.expo?.extra?.bugsnag?.apiKey
+    appConfig = getConfig(PROJECT_ROOT)
+    apiKey = appConfig?.exp?.extra?.bugsnag?.apiKey
   } catch (error) {
-    console.error(`Error: Failed to load app.json file ${PROJECT_ROOT}/app.json.\n${error}`)
+    console.error(`Error: Failed to read app config in ${PROJECT_ROOT}.\n${error}`)
     exit(1)
   }
 
   if (!apiKey) {
-    console.error('Error: No Bugsnag API key detected in app.json')
+    console.error('Error: No Bugsnag API key detected in app config')
     exit(1)
   }
 
@@ -47,8 +48,8 @@ const uploadSourceMaps = async () => {
     bundle,
     sourceMap,
     platform: 'android',
-    appVersion: appConfig?.expo?.version,
-    appVersionCode: appConfig?.expo?.android?.versionCode?.toString()
+    appVersion: appConfig?.exp?.version,
+    appVersionCode: appConfig?.exp?.android?.versionCode?.toString()
   }).then(() => {
     console.log(`Successfully uploaded the following files:\n${[bundle, sourceMap].join('\n')}`)
   }).catch(error => {

--- a/packages/plugin-expo-eas-sourcemaps/package.json
+++ b/packages/plugin-expo-eas-sourcemaps/package.json
@@ -23,7 +23,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "@bugsnag/source-maps": "^2.3.1"
+    "@bugsnag/source-maps": "^2.3.1",
+    "@expo/config": "^8.0.2"
   },
   "author": "Bugsnag",
   "license": "MIT"

--- a/packages/plugin-expo-eas-sourcemaps/src/android.js
+++ b/packages/plugin-expo-eas-sourcemaps/src/android.js
@@ -22,11 +22,13 @@ function setBugsnagConfig (config, androidManifest) {
   // Get the <application /> tag and assert if it doesn't exist.
   const mainApplication = getMainApplicationOrThrow(androidManifest)
 
-  addMetaDataItemToMainApplication(
-    mainApplication,
-    apiKeyName,
-    apiKeyValue
-  )
+  if (apiKeyValue) {
+    addMetaDataItemToMainApplication(
+      mainApplication,
+      apiKeyName,
+      apiKeyValue
+    )
+  }
 
   return androidManifest
 }

--- a/packages/plugin-expo-eas-sourcemaps/src/android.js
+++ b/packages/plugin-expo-eas-sourcemaps/src/android.js
@@ -1,0 +1,36 @@
+const { AndroidConfig, withAndroidManifest } = require('@expo/config-plugins')
+
+// Using helpers keeps error messages unified and helps cut down on XML format changes.
+const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = AndroidConfig.Manifest
+
+const withAndroidPlugin = (config, onPremConfig) => {
+// Set the Bugsnag API key in the android manifest - note that this isn't required for source map uploads
+// but is added here to support reporting builds using the fastlane plugin
+  config = withAndroidManifest(config, config => {
+    config.modResults = setBugsnagConfig(config, config.modResults)
+    return config
+  })
+
+  return config
+}
+
+// Splitting this function out of the mod makes it easier to test.
+function setBugsnagConfig (config, androidManifest) {
+  const apiKeyName = 'com.bugsnag.android.API_KEY'
+  const apiKeyValue = config?.extra?.bugsnag?.apiKey
+
+  // Get the <application /> tag and assert if it doesn't exist.
+  const mainApplication = getMainApplicationOrThrow(androidManifest)
+
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    apiKeyName,
+    apiKeyValue
+  )
+
+  return androidManifest
+}
+
+module.exports = {
+  withAndroidPlugin
+}


### PR DESCRIPTION
## Goal

This PR fixes two separate issues with the `plugin-expo-eas-sourcemaps` plugin:

- Reinstates the API key in the Android manifest - this was removed in v48 as it isn't required for sourcemap uploads but it may be used by the fastlane plugin, for example to report builds to Bugsnag (see #114)

- Fixes an EAS build failure when the Bugsnag config is defined in an `app.config.js` or `app.config.ts` file ( see https://github.com/bugsnag/bugsnag-expo/issues/118). The `eas-build-on-success` script now uses the `@expo/config` package to read the app's config instead of attempting to read directly from an `app.json` file. 
 
## Testing

Relied on CI, but also manually tested on an Expo 48 project with an `app.config.js` file