### PR TITLE
[PLAT-9891] read config from Constants.expoConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - (bugsnag-expo-cli) Updated bugsnag-expo-cli to support Typescript [#98](https://github.com/bugsnag/bugsnag-expo/pull/98)
+- Read API key and app version from `Constants.expoConfig` [#119](https://github.com/bugsnag/bugsnag-expo/pull/119)
 
 ### Fixed
 

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -45,20 +45,12 @@ const Bugsnag = {
 
     // read the api key from app.json if one is not explicitly passed
     if (!opts.apiKey) {
-      if (Constants.manifest?.extra?.bugsnag?.apiKey) {
-        opts.apiKey = Constants.manifest.extra.bugsnag.apiKey
-      } else if (Constants.manifest2?.extra?.expoClient?.extra?.bugsnag?.apiKey) {
-        opts.apiKey = Constants.manifest2.extra.expoClient.extra.bugsnag.apiKey
-      }
+      opts.apiKey = Constants.expoConfig.extra?.bugsnag?.apiKey
     }
 
     // read the version from app.json if one is not explicitly passed
     if (!opts.appVersion) {
-      if (Constants.manifest?.version) {
-        opts.appVersion = Constants.manifest.version
-      } else if (Constants.manifest2?.extra?.expoClient?.version) {
-        opts.appVersion = Constants.manifest2.extra.expoClient.version
-      }
+      opts.appVersion = Constants.expoConfig.version
     }
 
     const bugsnag = new Client(opts, schema, internalPlugins, { name, version, url })

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -3,14 +3,14 @@ const delivery = require('@bugsnag/delivery-expo')
 jest.mock('expo-constants', () => ({
   default: {
     platform: {},
-    manifest: {}
+    expoConfig: {}
   }
 }))
 
 jest.mock('../../plugin-expo-device/node_modules/expo-constants', () => ({
   default: {
     platform: {},
-    manifest: {}
+    expoConfig: {}
   }
 }))
 
@@ -19,7 +19,7 @@ jest.mock('../../plugin-expo-app/node_modules/expo-application', () => ({}))
 jest.mock('../../plugin-expo-app/node_modules/expo-constants', () => ({
   default: {
     platform: {},
-    manifest: {}
+    expoConfig: {}
   }
 }))
 

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -31,7 +31,7 @@ module.exports = {
       runtimeVersions: {
         reactNative: rnVersion,
         expoApp: Constants.expoVersion,
-        expoSdk: Constants.manifest?.sdkVersion || Constants.manifest2?.extra?.expoClient?.sdkVersion,
+        expoSdk: Constants.expoConfig.sdkVersion,
         androidApiLevel: Constants.platform.android ? String(Platform.Version) : undefined
       },
       totalMemory: Device.totalMemory

--- a/packages/plugin-expo-device/test/device.test.js
+++ b/packages/plugin-expo-device/test/device.test.js
@@ -16,7 +16,7 @@ describe('plugin: expo device', () => {
       default: {
         installationId: '123',
         platform: { android: {} },
-        manifest: { sdkVersion: SDK_VERSION },
+        expoConfig: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'standalone'
       }
@@ -84,7 +84,7 @@ describe('plugin: expo device', () => {
     jest.doMock('expo-constants', () => ({
       default: {
         platform: { ios: {} },
-        manifest: { sdkVersion: SDK_VERSION },
+        expoConfig: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'expo'
       }
@@ -148,7 +148,7 @@ describe('plugin: expo device', () => {
     jest.doMock('expo-constants', () => ({
       default: {
         platform: { ios: {} },
-        manifest: { sdkVersion: SDK_VERSION },
+        expoConfig: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'expo'
       }
@@ -195,7 +195,7 @@ describe('plugin: expo device', () => {
       default: {
         installationId: '123',
         platform: { ios: {} },
-        manifest: { sdkVersion: SDK_VERSION },
+        expoConfig: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'expo'
       }
@@ -269,7 +269,7 @@ describe('plugin: expo device', () => {
     jest.doMock('expo-constants', () => ({
       default: {
         platform: { ios: {} },
-        manifest: { sdkVersion: SDK_VERSION },
+        expoConfig: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
         appOwnership: 'guest'
       }


### PR DESCRIPTION
## Goal

Expo now has a standard API `Constants.expoConfig` for accessing the project's Expo config at runtime for development builds, EAS Builds and EAS Updates.

This updates the notifier to get the `apiKey`, `appVersion` and `sdkVersion` from `Constants.expoConfig` instead of having to check for the existence of `Constants.manifest`/ `Constants.manifest2`

## Testing

Existing CI, plus manually tested with development builds and EAS Update