### PR TITLE
Update expo-cli

### DIFF
--- a/packages/expo-cli/lib/insert.js
+++ b/packages/expo-cli/lib/insert.js
@@ -26,10 +26,12 @@ module.exports = async (projectRoot) => {
 
   if (checkFileExists('App.ts')) {
     return await writeBugsnagImport('App.ts')
+  } else if (checkFileExists('App.tsx')) {
+    return await writeBugsnagImport('App.tsx')
   } else if (checkFileExists('App.js')) {
     return await writeBugsnagImport('App.js')
   } else {
-    throw new Error(`Couldn’t find App.js or App.ts in "${projectRoot}". Is this the root of your Expo project?`)
+    throw new Error(`Couldn’t find App.js or App.ts/tsx in "${projectRoot}". Is this the root of your Expo project?`)
   }
 }
 

--- a/packages/expo-cli/lib/test/fixtures/blank-ts-and-js/App.tsx
+++ b/packages/expo-cli/lib/test/fixtures/blank-ts-and-js/App.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+
+export default class App extends React.Component {
+  render () {
+    return (
+      <View style={styles.container}>
+        <Text>Hello Expo!</Text>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+})

--- a/packages/expo-cli/lib/test/insert.test.js
+++ b/packages/expo-cli/lib/test/insert.test.js
@@ -69,10 +69,32 @@ describe('expo-cli: insert', () => {
       expect(appTsAfter).toBe(appTsBefore)
     })
   })
+  
+  it('shouldn’t insert if @bugsnag/expo is already imported (import, tsx)', async () => {
+    await withFixture('already-configured-ts-import', async (projectRoot) => {
+      const appTsBefore = await readFile(`${projectRoot}/App.tsx`, 'utf8')
+      const msg = await insert(projectRoot)
+      expect(msg).toMatch(/already/)
 
-  it('should provide a reasonable error when there is no App.js or App.ts', async () => {
+      const appTsAfter = await readFile(`${projectRoot}/App.txs`, 'utf8')
+      expect(appTsAfter).toBe(appTsBefore)
+    })
+  })
+
+  it('shouldn’t insert if @bugsnag/expo is already imported (require, tsx)', async () => {
+    await withFixture('already-configured-ts-require', async (projectRoot) => {
+      const appTsBefore = await readFile(`${projectRoot}/App.tsx`, 'utf8')
+      const msg = await insert(projectRoot)
+      expect(msg).toMatch(/already/)
+
+      const appTsAfter = await readFile(`${projectRoot}/App.tsx`, 'utf8')
+      expect(appTsAfter).toBe(appTsBefore)
+    })
+  })
+
+  it('should provide a reasonable error when there is no App.js or App.ts/tsx', async () => {
     await withFixture('empty-00', async (projectRoot) => {
-      await expect(insert(projectRoot)).rejects.toThrow(/^Couldn’t find App\.js or App\.ts in/)
+      await expect(insert(projectRoot)).rejects.toThrow(/^Couldn’t find App\.js or App\.ts\/tsx in/)
     })
   })
 


### PR DESCRIPTION
## Goal

By default when creating a new Expo project with the typescript template, the entry point file is `App.tsx` not `App.ts`, so the script to import and start Bugsnag fails. This update checks also for the `App.tsx` file and inserts if found.

## Design

Reused existing approach, only extended it

## Changeset

Extended existing functionality in `insert.js`, adding extra check for `App.tsx` file.

## Testing

Added tests for `App.tsx` extension.