### PR TITLE
Replace deprecated `Constants.manifest`

### DIFF
--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -19,7 +19,7 @@
     "expo-screen-orientation": "~6.0.2",
     "expo-status-bar": "~1.6.0",
     "react": "18.2.0",
-    "react-native": "0.72.1"
+    "react-native": "0.72.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jest-expo": "^48.0.1",
     "lerna": "^6.0.1",
     "react": "18.2.0",
-    "react-native": "0.72.1",
+    "react-native": "0.72.3",
     "verdaccio": "^5.10.2"
   },
   "scripts": {

--- a/packages/expo/src/config.js
+++ b/packages/expo/src/config.js
@@ -4,16 +4,10 @@ const { schema } = require('@bugsnag/core/config')
 const Constants = require('expo-constants').default
 const stringWithLength = require('@bugsnag/core/lib/validators/string-with-length')
 
-// If the developer property is not present in the manifest, it means the app is
+// If the developer property is not present it means the app is
 // not connected to a development tool and is either a published app running in
 // the Expo client, or a standalone app
-let IS_PRODUCTION = true
-
-if (Constants.manifest) {
-  IS_PRODUCTION = !Constants.manifest.developer
-} else if (Constants.manifest2) {
-  IS_PRODUCTION = !Constants.manifest2?.extra?.expoGo?.developer
-}
+const IS_PRODUCTION = !Constants.expoConfig.developer && !Constants.expoGoConfig.developer
 
 // The app can still run in production "mode" in development environments, in which
 // cases the global boolean __DEV__ will be set to true

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -28,7 +28,7 @@ const internalPlugins = [
   require('@bugsnag/plugin-expo-device'),
   require('@bugsnag/plugin-expo-app'),
   require('@bugsnag/plugin-console-breadcrumbs'),
-  require('@bugsnag/plugin-network-breadcrumbs')([NET_INFO_REACHABILITY_URL, Constants.manifest?.logUrl || Constants.manifest2?.extra?.expoGo?.logUrl]),
+  require('@bugsnag/plugin-network-breadcrumbs')([NET_INFO_REACHABILITY_URL, Constants.expoConfig.logUrl || Constants.expoGoConfig?.logUrl]),
   require('@bugsnag/plugin-expo-app-state-breadcrumbs'),
   require('@bugsnag/plugin-expo-connectivity-breadcrumbs'),
   require('@bugsnag/plugin-react-native-orientation-breadcrumbs'),

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -3,14 +3,16 @@ const delivery = require('@bugsnag/delivery-expo')
 jest.mock('expo-constants', () => ({
   default: {
     platform: {},
-    expoConfig: {}
+    expoConfig: {},
+    expoGoConfig: {}
   }
 }))
 
 jest.mock('../../plugin-expo-device/node_modules/expo-constants', () => ({
   default: {
     platform: {},
-    expoConfig: {}
+    expoConfig: {},
+    expoGoConfig: {}
   }
 }))
 
@@ -19,7 +21,8 @@ jest.mock('../../plugin-expo-app/node_modules/expo-application', () => ({}))
 jest.mock('../../plugin-expo-app/node_modules/expo-constants', () => ({
   default: {
     platform: {},
-    expoConfig: {}
+    expoConfig: {},
+    expoGoConfig: {}
   }
 }))
 

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -233,4 +233,59 @@ describe('expo notifier', () => {
       done()
     })
   })
+
+  describe('configuration', () => {
+    beforeEach(() => {
+      jest.resetModules()
+    })
+
+    it('sets a default value for releaseStage correctly (production)', () => {
+      jest.mock('expo-constants', () => ({
+        default: {
+          platform: {},
+          expoConfig: {},
+          expoGoConfig: {}
+        }
+      }))
+
+      const config = require('../src/config')
+      expect(config.releaseStage.defaultValue()).toBe('production')
+    })
+
+    it('sets a default value for releaseStage correctly (local-dev)', () => {
+      jest.mock('expo-constants', () => ({
+        default: {
+          platform: {},
+          expoConfig: {},
+          expoGoConfig: {
+            developer: {
+              tool: 'expo-cli'
+            }
+          }
+        }
+      }))
+
+      global.__DEV__ = true
+      const config = require('../src/config')
+      expect(config.releaseStage.defaultValue()).toBe('local-dev')
+    })
+
+    it('sets a default value for releaseStage correctly (local-prod)', () => {
+      jest.mock('expo-constants', () => ({
+        default: {
+          platform: {},
+          expoConfig: {
+            developer: {
+              tool: 'expo-cli'
+            }
+          },
+          expoGoConfig: {}
+        }
+      }))
+
+      global.__DEV__ = false
+      const config = require('../src/config')
+      expect(config.releaseStage.defaultValue()).toBe('local-prod')
+    })
+  })
 })


### PR DESCRIPTION
## Goal

`Constants.manifest` is deprecated in SDK 49 and now emits a warning when accessed: https://github.com/expo/fyi/blob/main/why-constants-expoconfig.md

This switches to using `Constants.expoConfig` which provides a consistent way to access the app config whether its an embedded build, Classic update or EAS update