### PR TITLE
Fix crash due to the calling .developer on null

### DIFF
--- a/packages/expo/src/config.js
+++ b/packages/expo/src/config.js
@@ -7,7 +7,7 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 // If the developer property is not present it means the app is
 // not connected to a development tool and is either a published app running in
 // the Expo client, or a standalone app
-const IS_PRODUCTION = !Constants.expoConfig.developer && !Constants.expoGoConfig.developer
+const IS_PRODUCTION = !Constants.expoConfig?.developer && !Constants.expoGoConfig?.developer
 
 // The app can still run in production "mode" in development environments, in which
 // cases the global boolean __DEV__ will be set to true


### PR DESCRIPTION
## Goal

Resolves: https://github.com/bugsnag/bugsnag-expo/issues/142

## Changeset

Just added `?.` in two places

## Testing

Tested using patch-package