### PR TITLE
Handle null Constants.expoConfig and Constants.expoGoConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixed
+
+- Fix a crash in configuration when Constants.expoGoConfig is null [#145](https://github.com/bugsnag/bugsnag-expo/pull/145)
+
 ## v49.0.0 (2023-07-13)
 
 This release adds support for expo 49

--- a/packages/expo/src/config.js
+++ b/packages/expo/src/config.js
@@ -7,7 +7,7 @@ const stringWithLength = require('@bugsnag/core/lib/validators/string-with-lengt
 // If the developer property is not present it means the app is
 // not connected to a development tool and is either a published app running in
 // the Expo client, or a standalone app
-const IS_PRODUCTION = !Constants.expoConfig.developer && !Constants.expoGoConfig.developer
+const IS_PRODUCTION = !Constants.expoConfig?.developer && !Constants.expoGoConfig?.developer
 
 // The app can still run in production "mode" in development environments, in which
 // cases the global boolean __DEV__ will be set to true

--- a/packages/expo/src/notifier.js
+++ b/packages/expo/src/notifier.js
@@ -28,7 +28,7 @@ const internalPlugins = [
   require('@bugsnag/plugin-expo-device'),
   require('@bugsnag/plugin-expo-app'),
   require('@bugsnag/plugin-console-breadcrumbs'),
-  require('@bugsnag/plugin-network-breadcrumbs')([NET_INFO_REACHABILITY_URL, Constants.expoConfig.logUrl || Constants.expoGoConfig?.logUrl]),
+  require('@bugsnag/plugin-network-breadcrumbs')([NET_INFO_REACHABILITY_URL, Constants.expoConfig?.logUrl || Constants.expoGoConfig?.logUrl]),
   require('@bugsnag/plugin-expo-app-state-breadcrumbs'),
   require('@bugsnag/plugin-expo-connectivity-breadcrumbs'),
   require('@bugsnag/plugin-react-native-orientation-breadcrumbs'),
@@ -45,12 +45,12 @@ const Bugsnag = {
 
     // read the api key from app.json if one is not explicitly passed
     if (!opts.apiKey) {
-      opts.apiKey = Constants.expoConfig.extra?.bugsnag?.apiKey
+      opts.apiKey = Constants.expoConfig?.extra?.bugsnag?.apiKey
     }
 
     // read the version from app.json if one is not explicitly passed
     if (!opts.appVersion) {
-      opts.appVersion = Constants.expoConfig.version
+      opts.appVersion = Constants.expoConfig?.version
     }
 
     const bugsnag = new Client(opts, schema, internalPlugins, { name, version, url })

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -4,7 +4,7 @@ jest.mock('expo-constants', () => ({
   default: {
     platform: {},
     expoConfig: {},
-    expoGoConfig: {}
+    expoGoConfig: null
   }
 }))
 
@@ -12,7 +12,7 @@ jest.mock('../../plugin-expo-device/node_modules/expo-constants', () => ({
   default: {
     platform: {},
     expoConfig: {},
-    expoGoConfig: {}
+    expoGoConfig: null
   }
 }))
 
@@ -22,7 +22,7 @@ jest.mock('../../plugin-expo-app/node_modules/expo-constants', () => ({
   default: {
     platform: {},
     expoConfig: {},
-    expoGoConfig: {}
+    expoGoConfig: null
   }
 }))
 
@@ -244,7 +244,7 @@ describe('expo notifier', () => {
         default: {
           platform: {},
           expoConfig: {},
-          expoGoConfig: {}
+          expoGoConfig: null
         }
       }))
 
@@ -256,7 +256,7 @@ describe('expo notifier', () => {
       jest.mock('expo-constants', () => ({
         default: {
           platform: {},
-          expoConfig: {},
+          expoConfig: null,
           expoGoConfig: {
             developer: {
               tool: 'expo-cli'
@@ -279,7 +279,7 @@ describe('expo notifier', () => {
               tool: 'expo-cli'
             }
           },
-          expoGoConfig: {}
+          expoGoConfig: null
         }
       }))
 

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -31,7 +31,7 @@ module.exports = {
       runtimeVersions: {
         reactNative: rnVersion,
         expoApp: Constants.expoVersion,
-        expoSdk: Constants.expoConfig.sdkVersion,
+        expoSdk: Constants.expoConfig?.sdkVersion,
         androidApiLevel: Constants.platform.android ? String(Platform.Version) : undefined
       },
       totalMemory: Device.totalMemory


### PR DESCRIPTION
## Goal

This PR builds on #143 which fixes a crash in configuration attempting to read a null `Constants.expoGoConfig` ( reported in #142)

The reported crash occurs because ExpoGoConfig is null in some circumstances, however the Expo docs state that both ExpoConfig and ExpoGoConfig could potentially be null, so this PR ensures guards are in place whenever either of those are accessed.