### PR TITLE
Support monorepo

### DIFF
--- a/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-expo-xcode.sh
+++ b/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-expo-xcode.sh
@@ -60,4 +60,11 @@ if [ ! -z "$ENDPOINT" ]; then
   ARGS+=("$ENDPOINT")
 fi
 
-../node_modules/.bin/bugsnag-source-maps upload-react-native "${ARGS[@]}"
+# Make sure that node binary exists
+source `$NODE_BINARY --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/node-binary.sh'"`
+
+# Retrieve the expo node binary
+BUGSNAG_EXPO_NODE_BINARY=$($NODE_BINARY --print "require('path').dirname(require.resolve('@bugsnag/source-maps/package.json'))")
+
+# Start upload the source maps to bugsnag
+$BUGSNAG_EXPO_NODE_BINARY upload-react-native "${ARGS[@]}"

--- a/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-xcode-build-phase
+++ b/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-xcode-build-phase
@@ -1,0 +1,8 @@
+if [[ -f "$PODS_ROOT/../.xcode.env" ]]; then
+    source "$PODS_ROOT/../.xcode.env"
+fi
+if [[ -f "$PODS_ROOT/../.xcode.env.local" ]]; then
+    source "$PODS_ROOT/../.xcode.env.local"
+fi
+
+SOURCE_MAP="$TMPDIR/$(md5 -qs "$CONFIGURATION_BUILD_DIR")-main.jsbundle.map" `$NODE_BINARY --print "require('path').dirname(require.resolve('@bugsnag/plugin-expo-eas-sourcemaps/package.json')) + '/lib/bugsnag-expo-xcode.sh'"`

--- a/packages/plugin-expo-eas-sourcemaps/src/ios.js
+++ b/packages/plugin-expo-eas-sourcemaps/src/ios.js
@@ -2,6 +2,8 @@ const {
   withInfoPlist,
   withXcodeProject
 } = require('@expo/config-plugins')
+const { readFileSync } = require('fs');
+const { dirname, join } = require('path');
 
 const buildPhaseName = 'PBXShellScriptBuildPhase'
 const buildPhaseComment = 'Bundle React Native code and images'
@@ -19,19 +21,7 @@ function withIosPlugin (config, onPremConfig) {
   config = withXcodeProject(config, config => {
     const xcodeProject = config.modResults
 
-    // 02. Update react native bundle phase with sourcemap filepath
-    const bundleReactNativePhase = xcodeProject.pbxItemByComment(buildPhaseComment, buildPhaseName)
-
-    const initialScript = bundleReactNativePhase.shellScript
-
-    const additionalExports = '"export EXTRA_PACKAGER_ARGS=\\"--sourcemap-output $TMPDIR/$(md5 -qs \\"$CONFIGURATION_BUILD_DIR\\")-main.jsbundle.map\\"\\n'
-
-    const modifiedScript = additionalExports + initialScript.substr(1)
-
-    bundleReactNativePhase.shellScript = modifiedScript
-
-    // 03. Configure the new build phase
-    const shellScript = 'SOURCE_MAP="$TMPDIR/$(md5 -qs "$CONFIGURATION_BUILD_DIR")-main.jsbundle.map" ../node_modules/@bugsnag/plugin-expo-eas-sourcemaps/lib/bugsnag-expo-xcode.sh'
+    const shellScript = readFileSync(join(__dirname, '../lib/bugsnag-xcode-build-phase'), 'utf8')
 
     xcodeProject.addBuildPhase([], buildPhaseName, 'Upload source maps to Bugsnag', null, {
       shellPath: '/bin/sh',


### PR DESCRIPTION
## Goal

When we setup bugsnag react native package, it doesn't support 100% monorepo. Apparently, the best option right now to support it is to perform hoisting on packages (if you are using yarn workspaces). The idea is to support a standalone package, but also monorepo.

## Design

To better locate the bugsnag sourcemap package. When executing under the xcode build phases, the relative path will not work if we are working under monorepo projects. With this approach, the problem gets solved.


## Changeset

1. Created xcode build phase script to add the node_binary to the execution context.
2. Changed the ios plugin to include the new build phase script 
3. Changed bash script to execute the bugsnag source maps binary regardless of the package location

Also refers to the bugsnag/source-maps package [PR87](https://github.com/bugsnag/bugsnag-source-maps/pull/87)

## Testing

Right now i just tested on my project. I would need some guidance in order to test it properly and not affect other developers. Feedback is needed 😄