### PR TITLE
Ensure EAS sourcemap config plugin is idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## TBD
+
+### Added
+
+- (delivery-expo) Explicitly mark failed payloads >1MB as not retryable [#65](https://github.com/bugsnag/bugsnag-expo/pull/65)
+
+### Fixed
+
+- (plugin-expo-eas-sourcemaps) Ensure EAS sourcemap config plugin is idempotent [#156](https://github.com/bugsnag/bugsnag-expo/pull/156)
+
 ## v49.0.1 (2023-08-03)
 
 ### Fixed


### PR DESCRIPTION
## Goal

Updates the iOS config plugin in `@bugsnag/plugin-expo-eas-sourcemaps` to ensure it can be run repeatedly.

This fixes an issue where the plugin would add duplicate build phases to the iOS project if `expo prebuild` is run repeatedly without the `--clean` option (#148)

Note that the Android config plugin is unaffected.

## Testing

CI plus manual testing