### PR TITLE
Fix build issues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,10 +39,10 @@ steps:
     key: "build-expo-ipa"
     timeout_in_minutes: 20
     agents:
-      queue: "opensource-arm-mac-cocoa-12"
+      queue: "macos-13-arm"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      DEVELOPER_DIR: "/Applications/Xcode14.app"
+      DEVELOPER_DIR: "/Applications/Xcode15.app"
     artifact_paths: build/output.ipa
     commands:
       - features/scripts/build-ios.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,7 +42,7 @@ steps:
       queue: "macos-13-arm"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      DEVELOPER_DIR: "/Applications/Xcode15.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.3.app"
       NODE_VERSION: "16"
     artifact_paths: build/output.ipa
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,6 +43,7 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       DEVELOPER_DIR: "/Applications/Xcode15.app"
+      NODE_VERSION: "16"
     artifact_paths: build/output.ipa
     commands:
       - features/scripts/build-ios.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,7 +42,7 @@ steps:
       queue: "macos-13-arm"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      DEVELOPER_DIR: "/Applications/Xcode14.3.app"
+      DEVELOPER_DIR: "/Applications/Xcode14.app"
       NODE_VERSION: "16"
     artifact_paths: build/output.ipa
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,11 +39,10 @@ steps:
     key: "build-expo-ipa"
     timeout_in_minutes: 20
     agents:
-      queue: "macos-13-arm"
+      queue: "opensource-arm-mac-cocoa-12"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       DEVELOPER_DIR: "/Applications/Xcode14.app"
-      NODE_VERSION: "16"
     artifact_paths: build/output.ipa
     commands:
       - features/scripts/build-ios.sh

--- a/features/fixtures/test-app/app.json
+++ b/features/fixtures/test-app/app.json
@@ -21,7 +21,8 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.bugsnag.expo.testfixture",
-      "buildNumber": "1"
+      "buildNumber": "1",
+      "jsEngine": "jsc"
     },
     "android": {
       "package": "com.bugsnag.expo.testfixture",

--- a/features/fixtures/test-app/app.json
+++ b/features/fixtures/test-app/app.json
@@ -22,7 +22,7 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.bugsnag.expo.testfixture",
       "buildNumber": "1",
-      "jsEngine": "jsc"
+      "jsEngine": "hermes"
     },
     "android": {
       "package": "com.bugsnag.expo.testfixture",

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@react-native-community/netinfo": "9.3.5",
-    "expo": "47.0.13",
+    "expo": "~47.0.13",
     "expo-application": "~5.0.1",
     "expo-constants": "~14.0.2",
     "expo-crypto": "~12.0.0",
@@ -19,7 +19,10 @@
     "expo-screen-orientation": "~5.0.1",
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
-    "react-native": "0.70.8"
+    "react-native": "0.70.14"
+  },
+  "resolutions": {
+    "expo-modules-core": "1.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3"

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -21,9 +21,6 @@
     "react": "18.1.0",
     "react-native": "0.70.14"
   },
-  "resolutions": {
-    "expo-modules-core": "1.0.4"
-  },
   "devDependencies": {
     "@babel/core": "^7.19.3"
   },

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -19,10 +19,7 @@
     "expo-screen-orientation": "~5.0.1",
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
-    "react-native": "0.70.5"
-  },
-  "resolutions": {
-    "expo-modules-core": "1.0.4"
+    "react-native": "0.70.14"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3"

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@react-native-community/netinfo": "9.3.5",
-    "expo": "~47.0.3",
+    "expo": "47.0.13",
     "expo-application": "~5.0.1",
     "expo-constants": "~14.0.2",
     "expo-crypto": "~12.0.0",
@@ -19,7 +19,7 @@
     "expo-screen-orientation": "~5.0.1",
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
-    "react-native": "0.70.14"
+    "react-native": "0.70.8"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3"


### PR DESCRIPTION
## Goal

This PR resolves build issues with Expo 47 by [using the hermes engine](https://docs.expo.dev/guides/using-hermes/#using-sdk-47-or-lower) as described in the [following issue](https://github.com/facebook/react-native/issues/41229#issuecomment-1784409448) and updates the version of react-native to match the one expected in `expo-doctor`

This also removes a previoiusly pinned dependency resolution implemented for a [known expo issue](https://github.com/expo/expo/issues/20679)
