### PR TITLE
Support Expo SDK 50

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,6 +32,7 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       NODE_VERSION: "18"
+      JAVA_VERSION: "17"
     artifact_paths: build/output.apk
     commands:
       - features/scripts/build-android.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,7 @@ steps:
       queue: "opensource-arm-mac-cocoa-12"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
+      NODE_VERSION: "18"
     artifact_paths: build/output.apk
     commands:
       - features/scripts/build-android.sh
@@ -43,6 +44,7 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       DEVELOPER_DIR: "/Applications/Xcode14.app"
+      NODE_VERSION: "18"
     artifact_paths: build/output.ipa
     commands:
       - features/scripts/build-ios.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,10 +41,10 @@ steps:
     key: "build-expo-ipa"
     timeout_in_minutes: 20
     agents:
-      queue: "opensource-arm-mac-cocoa-12"
+      queue: "macos-13-arm"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      DEVELOPER_DIR: "/Applications/Xcode14.app"
+      DEVELOPER_DIR: "/Applications/Xcode15.app"
       NODE_VERSION: "18"
     artifact_paths: build/output.ipa
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,7 +73,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':runner: expo iOS 15'
+  - label: ':runner: expo iOS 16'
     depends_on:
       - "build-expo-ipa"
       - "expo-maze-runner-image"
@@ -88,7 +88,7 @@ steps:
         command:
           - --app=build/output.ipa
           - --farm=bs
-          - --device=IOS_15
+          - --device=IOS_16
           - --a11y-locator
           - --retry=2
           - --order=random
@@ -96,7 +96,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':runner: expo iOS 13'
+  - label: ':runner: expo iOS 14'
     depends_on:
       - "build-expo-ipa"
       - "expo-maze-runner-image"
@@ -111,7 +111,7 @@ steps:
         command:
           - --app=build/output.ipa
           - --farm=bs
-          - --device=IOS_13
+          - --device=IOS_14
           - --a11y-locator
           - --retry=2
           - --order=random

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,7 +44,7 @@ steps:
       queue: "macos-13-arm"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      DEVELOPER_DIR: "/Applications/Xcode15.app"
+      DEVELOPER_DIR: "/Applications/Xcode-15.2.0.app"
       NODE_VERSION: "18"
     artifact_paths: build/output.ipa
     commands:
@@ -69,7 +69,7 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-    concurrency: 5 
+    concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,8 +21,6 @@ jobs:
 
     - run: npm install --no-audit --no-package-lock
 
-    - run: npx lerna bootstrap --no-ci
-
     - run: npm run test:unit
 
     - run: npm run test:lint

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14']
+        node-version: ['18']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ compile_commands.json
 .cache
 .clangd
 package-lock.json
+yarn.lock
 /config

--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ cd bugsnag-expo
 # Install top-level dependencies
 npm i
 
-# Bootstrap all of the packages
-npm run bootstrap
-
 # Run the unit tests
 npm run test:unit
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,12 +15,6 @@ Install top level dependencies:
 npm i
 ```
 
-Bootstrap all of the individual packages:
-
-```sh
-npm run bootstrap
-```
-
 ## Unit tests
 
 Runs the unit tests for each package.

--- a/features/auto_breadcrumbs.feature
+++ b/features/auto_breadcrumbs.feature
@@ -117,7 +117,7 @@ Scenario: Network breadcrumbs are captured by default
   And the exception "message" equals "defaultNetworkBreadcrumbsBehaviour"
   And the event has a "request" breadcrumb named "XMLHttpRequest succeeded"
   And the event "breadcrumbs.1.metaData.status" equals 200
-  And the event "breadcrumbs.1.metaData.request" equals "GET http://postman-echo.com/get"
+  And the event "breadcrumbs.1.metaData.request" equals "GET https://postman-echo.com/get"
   And the error Bugsnag-Integrity header is valid
 
 Scenario: Network breadcrumbs can be disabled explicitly
@@ -152,5 +152,5 @@ Scenario: Network breadcrumbs overrides auto-breadcrumbs
   And the exception "message" equals "overrideNetworkBreadcrumbsBehaviour"
   And the event has a "request" breadcrumb named "XMLHttpRequest succeeded"
   And the event "breadcrumbs.0.metaData.status" equals 200
-  And the event "breadcrumbs.0.metaData.request" equals "GET http://postman-echo.com/get"
+  And the event "breadcrumbs.0.metaData.request" equals "GET https://postman-echo.com/get"
   And the error Bugsnag-Integrity header is valid

--- a/features/fixtures/.gitignore
+++ b/features/fixtures/.gitignore
@@ -1,1 +1,0 @@
-packages/

--- a/features/fixtures/test-app/.gitignore
+++ b/features/fixtures/test-app/.gitignore
@@ -1,18 +1,35 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
 node_modules/
+
+# Expo
 .expo/
 dist/
-npm-debug.*
+web-build/
+
+# Native
+*.orig.*
 *.jks
 *.p8
 *.p12
 *.key
 *.mobileprovision
-scenario.json
-bugsnag-expo-*.tgz
-android
-ios
-*.orig.*
-web-build/
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
 
 # macOS
 .DS_Store
+*.pem
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo

--- a/features/fixtures/test-app/app.json
+++ b/features/fixtures/test-app/app.json
@@ -21,7 +21,16 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.bugsnag.expo.testfixture",
-      "buildNumber": "1"
+      "buildNumber": "1",
+      "infoPlist": {
+        "NSAppTransportSecurity": {
+            "NSExceptionDomains": {
+              "bs-local.com": {
+                "NSExceptionAllowsInsecureHTTPLoads": true
+              }
+          }
+        }
+      }
     },
     "android": {
       "package": "com.bugsnag.expo.testfixture",

--- a/features/fixtures/test-app/app/network_breadcrumbs.js
+++ b/features/fixtures/test-app/app/network_breadcrumbs.js
@@ -60,7 +60,7 @@ export default class NetworkBreadcrumbs extends Component {
   }
 
   async triggerNetworkBreadcrumbsError(client, message) {
-    await fetch("http://postman-echo.com/get")
+    await fetch("https://postman-echo.com/get")
       .then(response => {
         client.notify(new Error(message))
       })

--- a/features/fixtures/test-app/index.js
+++ b/features/fixtures/test-app/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/features/fixtures/test-app/metro.config.js
+++ b/features/fixtures/test-app/metro.config.js
@@ -1,15 +1,21 @@
-const { getDefaultConfig } = require('@expo/metro-config');
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
 
-const defaultConfig = getDefaultConfig(__dirname);
+// Find the project and workspace directories
+const projectRoot = __dirname;
+// This can be replaced with `find-yarn-workspace-root`
+const workspaceRoot = path.resolve(projectRoot, '../..');
 
-defaultConfig.resolver.extraNodeModules = {
-  'expo': `${__dirname}/node_modules/expo`,
-  'expo-modules-core': `${__dirname}/node_modules/expo-modules-core`,
-  'react-native': `${__dirname}/node_modules/react-native`,
-  'react': `${__dirname}/node_modules/react`,
-  '@babel/runtime': `${__dirname}/node_modules/@babel/runtime`,
-  'promise': `${__dirname}/node_modules/promise`,
-  '@unimodules/core': `${__dirname}/node_modules/@unimodules/core`,
-}
+const config = getDefaultConfig(projectRoot);
 
-module.exports = defaultConfig;
+// 1. Watch all files within the monorepo
+config.watchFolders = [workspaceRoot];
+// 2. Let Metro know where to resolve packages and in what order
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(workspaceRoot, 'node_modules'),
+];
+// 3. Force Metro to resolve (sub)dependencies only from the `nodeModulesPaths`
+// config.resolver.disableHierarchicalLookup = true;
+
+module.exports = config;

--- a/features/fixtures/test-app/metro.config.js
+++ b/features/fixtures/test-app/metro.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 // Find the project and workspace directories
 const projectRoot = __dirname;
 // This can be replaced with `find-yarn-workspace-root`
-const workspaceRoot = path.resolve(projectRoot, '../..');
+const workspaceRoot = path.resolve(projectRoot, '../../..');
 
 const config = getDefaultConfig(projectRoot);
 

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-fixture",
   "version": "1.0.0",
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -19,7 +19,10 @@
     "expo-screen-orientation": "~6.4.1",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
-    "react-native": "0.73.2"
+    "react-native": "0.73.2",
+    "@bugsnag/expo": "*",
+    "bugsnag-expo-cli": "*",
+    "@bugsnag/plugin-expo-eas-sourcemaps": "*"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -9,17 +9,17 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@react-native-community/netinfo": "9.3.10",
-    "expo": "^49.0.0",
-    "expo-application": "~5.3.0",
-    "expo-constants": "~14.4.2",
-    "expo-crypto": "~12.4.1",
-    "expo-device": "~5.4.0",
-    "expo-file-system": "~15.4.2",
-    "expo-screen-orientation": "~6.0.2",
-    "expo-status-bar": "~1.6.0",
+    "@react-native-community/netinfo": "11.1.0",
+    "expo": "^50.0.0",
+    "expo-application": "~5.8.3",
+    "expo-constants": "~15.4.5",
+    "expo-crypto": "~12.8.0",
+    "expo-device": "~5.9.3",
+    "expo-file-system": "~16.0.5",
+    "expo-screen-orientation": "~6.4.1",
+    "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
-    "react-native": "0.72.3"
+    "react-native": "0.73.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -20,12 +20,13 @@
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
     "react-native": "0.73.2",
-    "@bugsnag/expo": "*",
-    "bugsnag-expo-cli": "*",
-    "@bugsnag/plugin-expo-eas-sourcemaps": "*"
+    "@bugsnag/expo": "*"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0"
+    "@babel/core": "^7.20.0",
+    "bugsnag-expo-cli": "*",
+    "@bugsnag/plugin-expo-eas-sourcemaps": "*",
+    "@bugsnag/source-maps": "^2.3.1"
   },
   "private": true
 }

--- a/features/scripts/build-android.sh
+++ b/features/scripts/build-android.sh
@@ -4,7 +4,7 @@ set -e
 
 pushd features/fixtures/test-app
 
-eas build \
+npx eas-cli@latest build \
   --local \
   -p android \
   --output output.apk

--- a/features/scripts/build-common.sh
+++ b/features/scripts/build-common.sh
@@ -7,20 +7,12 @@ git clean -xfdf
 # And the yarn cache is clean
 yarn cache clean --all
 
-# Install expo requirements
-npm install
-
-# Bump package versions to a high value so only our values will match
-npx lerna version 999.999.999 --no-git-tag-version --no-push --no-changelog --yes
-
-# Pack the packages and move them to the test fixture
-npm pack packages/*/
-mv *.tgz features/fixtures/test-app
+# Install repo dependencies
+yarn install
 
 cd features/fixtures/test-app
 
-# Install the bugsnag-expo-cli and run setup
-npm install bugsnag-expo-cli*.tgz
+# Set the api key via the CLI
 ./run-bugsnag-expo-cli
 
 # Set EAS Project ID
@@ -28,11 +20,6 @@ sed -i '' "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
 
 # set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
 ./set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT
-
-# install the remaining packages, this also re-installs the correct @bugsnag/expo version
-npm install *.tgz
-npm install
-yarn import
 
 ./run-bugsnag-expo-cli-install
 

--- a/features/scripts/build-ios.sh
+++ b/features/scripts/build-ios.sh
@@ -4,7 +4,7 @@ set -e
 
 pushd features/fixtures/test-app
 
-eas build \
+npx eas-cli@latest build \
   --local \
   -p ios \
   --output output.ipa \

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,10 @@ const project = (displayName, packageNames, config = {}) => ({
 const extensions = 'js,jsx,ts,tsx'
 
 module.exports = {
+  preset: 'jest-expo',
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|native-base|react-native-svg)'
+  ],
   collectCoverageFrom: [
     `**/packages/*/**/*.{${extensions}}`,
     `!**/*.test.{${extensions}}`,

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,4 @@
 {
-  "lerna": "2.11.0",
-  "packages": [
-    "packages/*"
-  ],
-  "version": "49.0.2"
+  "version": "49.0.2",
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "expo": "^50.0.0",
     "jest": "^29.3.1",
     "jest-expo": "^50.0.1",
-    "lerna": "^6.0.1",
+    "lerna": "^8.0.2",
     "react": "18.2.0",
     "react-native": "0.73.2",
     "verdaccio": "^5.10.2"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*", "features/fixtures/test-app"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-standard": "^4.0.1",
-    "expo": "^49.0.0",
-    "jest": "^26.6.3",
-    "jest-expo": "^48.0.1",
+    "expo": "^50.0.0",
+    "jest": "^29.3.1",
+    "jest-expo": "^50.0.1",
     "lerna": "^6.0.1",
     "react": "18.2.0",
-    "react-native": "0.72.3",
+    "react-native": "0.73.2",
     "verdaccio": "^5.10.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "test:lint": "eslint --report-unused-disable-directives --max-warnings=0 .",
     "local-npm:start": "verdaccio --config ./verdaccio-config.yml",
     "local-npm:publish-all": "lerna publish --yes --force-publish --exact --no-push --no-git-reset --no-git-tag-version --registry 'http://localhost:4873'"
-  }
+  },
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/packages/delivery-expo/package.json
+++ b/packages/delivery-expo/package.json
@@ -18,14 +18,14 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "@react-native-community/netinfo": "9.3.10",
-    "expo-crypto": "~12.4.0",
-    "expo-file-system": "~15.4.2"
+    "@react-native-community/netinfo": "11.1.0",
+    "expo-crypto": "~12.8.0",
+    "expo-file-system": "~16.0.1"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "@react-native-community/netinfo": "9.3.10",
-    "expo-crypto": "~12.4.0",
-    "expo-file-system": "~15.4.2"
+    "@react-native-community/netinfo": "11.1.0",
+    "expo-crypto": "~12.8.0",
+    "expo-file-system": "~16.0.1"
   }
 }

--- a/packages/expo-cli/lib/version-information.js
+++ b/packages/expo-cli/lib/version-information.js
@@ -1,7 +1,7 @@
 const semver = require('semver')
 
 // the major version number of the latest Expo SDK we support
-const LATEST_SUPPORTED_EXPO_SDK = 49
+const LATEST_SUPPORTED_EXPO_SDK = 50
 
 class Version {
   constructor (expoSdkVersion, bugsnagVersion, isLegacy = false) {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -49,11 +49,11 @@
     "bugsnag-build-reporter": "^2.0.0"
   },
   "devDependencies": {
-    "expo-constants": "~14.4.2"
+    "expo-constants": "~15.4.1"
   },
   "peerDependencies": {
-    "expo": "^49.0.0",
-    "expo-constants": "~14.4.2",
+    "expo": "^50.0.0",
+    "expo-constants": "~15.4.1",
     "promise": "^8.3.0",
     "react": "*"
   }

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 const delivery = require('@bugsnag/delivery-expo')
 
 jest.mock('expo-constants', () => ({

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -12,7 +12,7 @@ jest.mock('expo-constants', () => ({
   }
 }))
 
-jest.mock('../../plugin-expo-device/node_modules/expo-constants', () => ({
+jest.mock('../../../node_modules/expo-constants', () => ({
   default: {
     platform: {},
     expoConfig: {},
@@ -20,9 +20,9 @@ jest.mock('../../plugin-expo-device/node_modules/expo-constants', () => ({
   }
 }))
 
-jest.mock('../../plugin-expo-app/node_modules/expo-application', () => ({}))
+jest.mock('../../../node_modules/expo-application', () => ({}))
 
-jest.mock('../../plugin-expo-app/node_modules/expo-constants', () => ({
+jest.mock('../../../node_modules/expo-constants', () => ({
   default: {
     platform: {},
     expoConfig: {},
@@ -31,7 +31,7 @@ jest.mock('../../plugin-expo-app/node_modules/expo-constants', () => ({
 }))
 
 jest.mock('@bugsnag/delivery-expo')
-jest.mock('../../delivery-expo/node_modules/expo-crypto', () => ({}))
+jest.mock('../../../node_modules/expo-crypto', () => ({}))
 
 jest.mock('react-native', () => ({
   NativeModules: {
@@ -61,7 +61,7 @@ jest.mock('react-native', () => ({
   }
 }))
 
-jest.mock('../../delivery-expo/node_modules/expo-file-system', () => ({
+jest.mock('../../../node_modules/expo-file-system', () => ({
   cacheDirectory: 'file://var/data/foo.bar.app/',
   downloadAsync: jest.fn(() => Promise.resolve({ md5: 'md5', uri: 'uri' })),
   getInfoAsync: jest.fn(() => Promise.resolve({ exists: true, md5: 'md5', uri: 'uri' })),
@@ -75,17 +75,17 @@ jest.mock('../../delivery-expo/node_modules/expo-file-system', () => ({
   createDownloadResumable: jest.fn(() => Promise.resolve())
 }))
 
-jest.mock('../../delivery-expo/node_modules/@react-native-community/netinfo', () => ({
+jest.mock('../../../node_modules/@react-native-community/netinfo', () => ({
   addEventListener: jest.fn(),
   fetch: () => Promise.resolve({ isConnected: true })
 }))
 
-jest.mock('../../plugin-expo-connectivity-breadcrumbs/node_modules/@react-native-community/netinfo', () => ({
+jest.mock('../../../node_modules/@react-native-community/netinfo', () => ({
   addEventListener: jest.fn(),
   fetch: () => Promise.resolve({ isConnected: true })
 }))
 
-jest.doMock('../../plugin-expo-device/node_modules/expo-device', () => ({
+jest.doMock('../../../node_modules/expo-device', () => ({
   manufacturer: 'Google',
   modelName: 'Pixel 4'
 }))

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 
 const delivery = require('@bugsnag/delivery-expo')
 
@@ -89,6 +86,14 @@ jest.doMock('../../../node_modules/expo-device', () => ({
   manufacturer: 'Google',
   modelName: 'Pixel 4'
 }))
+
+const networkBreadcrumbsPlugin = {
+  load: () => () => {}
+}
+
+jest.mock('../../../node_modules/@bugsnag/plugin-network-breadcrumbs', () => {
+  return () => networkBreadcrumbsPlugin
+})
 
 global.ErrorUtils = {
   setGlobalHandler: jest.fn(),

--- a/packages/plugin-expo-app/package.json
+++ b/packages/plugin-expo-app/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.19.0",
-    "expo-application": "~5.3.0",
-    "expo-constants": "~14.4.2"
+    "expo-application": "~5.8.0",
+    "expo-constants": "~15.4.1"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "expo-application": "~5.3.0",
-    "expo-constants": "~14.4.2"
+    "expo-application": "~5.8.0",
+    "expo-constants": "~15.4.1"
   }
 }

--- a/packages/plugin-expo-connectivity-breadcrumbs/package.json
+++ b/packages/plugin-expo-connectivity-breadcrumbs/package.json
@@ -18,10 +18,10 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "@react-native-community/netinfo": "9.3.10"
+    "@react-native-community/netinfo": "11.1.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "@react-native-community/netinfo": "9.3.10"
+    "@react-native-community/netinfo": "11.1.0"
   }
 }

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -18,12 +18,12 @@
   "license": "MIT",
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
-    "expo-constants": "~14.4.2",
-    "expo-device": "~5.4.0"
+    "expo-constants": "~15.4.1",
+    "expo-device": "~5.9.0"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
-    "expo-constants": "~14.4.2",
-    "expo-device": "~5.4.0"
+    "expo-constants": "~15.4.1",
+    "expo-device": "~5.9.0"
   }
 }

--- a/packages/plugin-expo-eas-sourcemaps/package.json
+++ b/packages/plugin-expo-eas-sourcemaps/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@bugsnag/source-maps": "^2.3.1",
-    "@expo/config": "^8.1.1"
+    "@expo/config": "^8.5.1"
   },
   "author": "Bugsnag",
   "license": "MIT"


### PR DESCRIPTION
## Goal

Adds support for Expo SDK 50

## Changeset

- Bumped dependencies for Expo 50
- Updated the CI pipeline to run on Java 17, Node 18 and Xcode 15
- Updated lerna to v8.0.2
- Updated jest to v29.3.1 and enabled the `jest-expo` preset for unit tests.
- Updated the test fixture:
	- The test fixture is now part of the monorepo (as a private package)
	- The test fixture build now leverages yarn workspaces to install the bugsnag dependencies (required for building with EAS in a monorepo)
- iOS tests now run against iOS 14 and 16 (13.4 is now the minimum in Expo 50/React Native 0.73)
	
## Testing

Relied on CI and unit tests