### PR TITLE
Fix release script

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -20,7 +20,6 @@ git clone --single-branch \
 cd /app/bugsnag-expo
 
 npm install --package-lock false
-npx lerna bootstrap -- --package-lock false
 
 if [ -v RETRY_PUBLISH ]; then
   npx lerna publish from-package

--- a/dockerfiles/Dockerfile.release
+++ b/dockerfiles/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 RUN apk add --update git bash python3 make gcc g++ openssh-client curl
 
 RUN addgroup -S admins

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@bugsnag/expo": "^50.0.0",
+    "@bugsnag/expo": "*",
     "@react-native-community/netinfo": "11.1.0",
     "expo": "^50.0.0",
     "expo-application": "~5.8.3",
@@ -24,9 +24,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@bugsnag/plugin-expo-eas-sourcemaps": "^50.0.0",
+    "@bugsnag/plugin-expo-eas-sourcemaps": "*",
     "@bugsnag/source-maps": "^2.3.1",
-    "bugsnag-expo-cli": "^50.0.0"
+    "bugsnag-expo-cli": "*"
   },
   "private": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,5 @@
 {
   "version": "50.0.0",
-  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "packages": ["packages/*"]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "verdaccio": "^5.10.2"
   },
   "scripts": {
-    "bootstrap": "lerna bootstrap",
     "test:unit": "jest",
     "test:lint": "eslint --report-unused-disable-directives --max-warnings=0 .",
     "local-npm:start": "verdaccio --config ./verdaccio-config.yml",


### PR DESCRIPTION
## Goal

Mops up some required updates to the release script/process that were missed for v50

## Changeset

- Bumped release image to Node 18
- Removed deprecated lerna bootstrap command from release script and package.json
- Added `packages` config to lerna to exclude the test fixture from lerna operations - the test fixture is already a private package so doesn't get published, but this prevents lerna bumping the test fixture dependencies on release, which we don't want to do as we always want to use the latest packages directly from the monorepo