### PR TITLE
[PLAT-11248] Add missing fastlane gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods'
+gem 'fastlane'
 
 gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'
 


### PR DESCRIPTION
## Goal

Ensure that builds work on the new CI setup

## Changeset

Add `fastlane` to the Gemfile

## Testing

Covered by CI