### PR TITLE
Move Android tests to macos 13 boxes and update the version of cocoapods to 1.14.3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,7 @@ steps:
     key: "build-expo-apk"
     timeout_in_minutes: 20
     agents:
-      queue: "opensource-arm-mac-cocoa-12"
+      queue: "macos-13-arm"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       NODE_VERSION: "18"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods'
+gem 'cocoapods', '~> 1.14.3'
 gem 'fastlane'
 
 gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'


### PR DESCRIPTION
## Goal

Ensure that iOS and Android test run on CI

## Changeset

Moved Android steps to Macos 13 ARM boxes
Updated the version of Cocoapods to 1.14.3

## Testing

Covered by CI