### PR TITLE
Replace Constants.installationId with a generated device id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+## Breaking Changes
+
+This release contains an additional peer dependency on `expo-secure-store`. Run the bugsnag-expo-cli to add this dependency to your project:
+
+```sh
+npx bugsnag-expo-cli install
+```
+
+Alternatively, you can use `expo install`:
+
+```sh
+expo install expo-secure-store
+```
+
+## Changed
+
+- (plugin-expo-device) Replace `Constants.installationId` with a generated device id [#181](https://github.com/bugsnag/bugsnag-expo/pull/181)
+
 ## v50.0.0 (2024-02-07)
 
 This release adds support for expo 50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,7 @@
 
 ## Breaking Changes
 
-This release contains an additional peer dependency on `expo-secure-store`. Run the bugsnag-expo-cli to add this dependency to your project:
-
-```sh
-npx bugsnag-expo-cli install
-```
-
-Alternatively, you can use `expo install`:
-
-```sh
-expo install expo-secure-store
-```
+This release contains an additional peer dependency on `expo-secure-store`. See the [upgrade guide](UPGRADING.md) for more information.
 
 ## Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,17 @@
 
 Thanks for stopping by! This document should cover most topics surrounding contributing to this repo.
 
-* [How to contribute](#how-to-contribute)
-  * [Reporting issues](#reporting-issues)
-  * [Fixing issues](#fixing-issues)
-  * [Adding features](#adding-features)
-* [System requirements](#system-requirements)
-* [Testing](#testing)
+- [Contributing](#contributing)
+  - [Reporting issues](#reporting-issues)
+    - [Fixing issues](#fixing-issues)
+    - [Adding features](#adding-features)
+  - [System requirements](#system-requirements)
+  - [Testing](#testing)
+  - [CI](#ci)
+  - [Keeping dependencies in sync](#keeping-dependencies-in-sync)
+  - [Updating the CLI to install a compatible notifier version](#updating-the-cli-to-install-a-compatible-notifier-version)
+  - [Releases](#releases)
+    - [Prereleases](#prereleases)
 
 ## Reporting issues
 Are you having trouble getting started? Please [contact us directly](mailto:support@bugsnag.com?subject=%5BGitHub%5D%20bugsnag-expo%20-%20having%20trouble%20getting%20started%20with%20Bugsnag) for assistance with integrating Bugsnag into your application.
@@ -73,6 +78,7 @@ The following modules are currently used:
 - `expo-crypto` (`@bugsnag/delivery-expo`)
 - `expo-device` (`@bugsnag/plugin-expo-device`)
 - `expo-file-system` (`@bugsnag/delivery-expo`)
+- `expo-secure-store` (`@bugsnag/plugin-expo-device`)
 
 If you add a new dependency please add it to this list.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,15 @@
+# Upgrading
+
+## v50.x to v51.x
+
+This release contains an additional peer dependency on `expo-secure-store`. Run the bugsnag-expo-cli to add this dependency to your project:
+
+```sh
+npx bugsnag-expo-cli install
+```
+
+Alternatively, you can use `expo install`:
+
+```sh
+expo install expo-secure-store
+```

--- a/features/device.feature
+++ b/features/device.feature
@@ -11,10 +11,7 @@ Scenario: Device data is included by default
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "DeviceDefaultError"
-
-  # Skipped pending PLAT-12140
-  # And the event "device.id" is not null
-
+  And the event "device.id" is not null
   And the event "device.manufacturer" is not null
   And the event "device.osName" equals the current OS name
   And the event "device.osVersion" is not null
@@ -32,10 +29,7 @@ Scenario: Device data can be modified by a callback
   Then I wait to receive an error
   And the exception "errorClass" equals "Error"
   And the exception "message" equals "DeviceCallbackError"
-
-  # Skipped pending PLAT-12140
-  # And the event "device.id" is not null
-  
+  And the event "device.id" is not null
   And the event "device.manufacturer" is not null
   And the event "device.osVersion" is not null
   And the event "device.osName" equals the current OS name
@@ -48,3 +42,19 @@ Scenario: Device data can be modified by a callback
   And the event "device.totalMemory" is not null
   And the event "metaData.device.isDevice" is true
   And the error Bugsnag-Integrity header is valid
+
+Scenario: Device id is persisted across app starts
+  Given the element "deviceDefaultButton" is present
+  When I click the element "deviceDefaultButton"
+  Then I wait to receive an error
+  And the event "device.id" is not null
+  And the error payload field "events.0.device.id" is stored as the value "device_id"
+  And I discard the oldest error
+
+  When I close and relaunch the app
+  And the element "deviceFeature" is present
+  And I click the element "deviceFeature"
+  And the element "deviceDefaultButton" is present
+  And I click the element "deviceDefaultButton"
+  And I wait to receive an error
+  Then the error payload field "events.0.device.id" equals the stored value "device_id"

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -18,6 +18,7 @@
     "expo-device": "~6.0.2",
     "expo-file-system": "~17.0.1",
     "expo-screen-orientation": "~7.0.4",
+    "expo-secure-store": "~13.0.1",
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",
     "react-native": "0.74.1"

--- a/features/steps/browserstack_steps.rb
+++ b/features/steps/browserstack_steps.rb
@@ -42,3 +42,8 @@ When("I clear any error dialogue") do
                     click_if_present('android:id/aerr_restart')
   end
 end
+
+When("I close and relaunch the app") do
+  Maze.driver.terminate_app Maze.driver.app_id
+  Maze.driver.activate_app Maze.driver.app_id
+end

--- a/features/user.feature
+++ b/features/user.feature
@@ -23,12 +23,11 @@ Scenario: User data can be set via a callback
   And the event "user.name" equals "userCallbackName"
   And the error Bugsnag-Integrity header is valid
 
-# Skipped pending PLAT-12140
-# Scenario: User id defaults to device id
-#   Given the element "userDefaultButton" is present
-#   When I click the element "userDefaultButton"
-#   Then I wait to receive an error
-#   And the exception "errorClass" equals "Error"
-#   And the exception "message" equals "UserDefaultError"
-#   And the event "user.id" is not null
-#   And the error Bugsnag-Integrity header is valid
+Scenario: User id defaults to device id
+  Given the element "userDefaultButton" is present
+  When I click the element "userDefaultButton"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "Error"
+  And the exception "message" equals "UserDefaultError"
+  And the event "user.id" is not null
+  And the error Bugsnag-Integrity header is valid

--- a/packages/expo-cli/lib/test/fixtures/already-installed-postv7-js/package.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-postv7-js/package.json
@@ -9,7 +9,8 @@
     "expo-constants": "*",
     "expo-crypto": "*",
     "expo-device": "*",
-    "expo-file-system": "*"
+    "expo-file-system": "*",
+    "expo-secure-store":"*"
   },
   "scripts": {
     "eas-build-on-success": "npx bugsnag-eas-build-on-success"

--- a/packages/expo-cli/lib/test/fixtures/already-installed-postv7-ts/package.json
+++ b/packages/expo-cli/lib/test/fixtures/already-installed-postv7-ts/package.json
@@ -9,7 +9,8 @@
     "expo-constants": "*",
     "expo-crypto": "*",
     "expo-device": "*",
-    "expo-file-system": "*"
+    "expo-file-system": "*",
+    "expo-secure-store":"*"
   },
   "scripts": {
     "eas-build-on-success": "npx bugsnag-eas-build-on-success"

--- a/packages/expo-cli/lib/test/fixtures/dependencies-only-00/package.json
+++ b/packages/expo-cli/lib/test/fixtures/dependencies-only-00/package.json
@@ -8,6 +8,7 @@
     "expo-constants": "*",
     "expo-crypto": "*",
     "expo-device": "*",
-    "expo-file-system": "*"
+    "expo-file-system": "*",
+    "expo-secure-store":"*"
   }
 }

--- a/packages/expo-cli/lib/test/install.test.js
+++ b/packages/expo-cli/lib/test/install.test.js
@@ -19,7 +19,8 @@ describe('expo-cli: install', () => {
           'expo-constants',
           'expo-crypto',
           'expo-device',
-          'expo-file-system'
+          'expo-file-system',
+          'expo-secure-store'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
 
@@ -55,6 +56,7 @@ describe('expo-cli: install', () => {
           'expo-crypto',
           'expo-device',
           'expo-file-system',
+          'expo-secure-store',
           '--npm'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
@@ -91,6 +93,7 @@ describe('expo-cli: install', () => {
           'expo-crypto',
           'expo-device',
           'expo-file-system',
+          'expo-secure-store',
           '--yarn'
         ])
         expect(opts).toEqual({ cwd: projectRoot })
@@ -127,6 +130,7 @@ describe('expo-cli: install', () => {
           'expo-crypto',
           'expo-device',
           'expo-file-system',
+          'expo-secure-store',
           '--npm',
           '--yarn'
         ])
@@ -175,7 +179,7 @@ describe('expo-cli: install', () => {
     const install = require('../install')
 
     await withFixture('blank-js', async (projectRoot) => {
-      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/expo @react-native-community/netinfo expo-application expo-constants expo-crypto expo-device expo-file-system"
+      const expected = `Command exited with non-zero exit code (1) "expo install @bugsnag/expo @react-native-community/netinfo expo-application expo-constants expo-crypto expo-device expo-file-system expo-secure-store"
 stdout:
 some data on stdout
 

--- a/packages/expo-cli/lib/utils.js
+++ b/packages/expo-cli/lib/utils.js
@@ -40,6 +40,7 @@ module.exports = {
     'expo-constants',
     'expo-crypto',
     'expo-device',
-    'expo-file-system'
+    'expo-file-system',
+    'expo-secure-store'
   ]
 }

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -87,6 +87,12 @@ jest.doMock('../../../node_modules/expo-device', () => ({
   modelName: 'Pixel 4'
 }))
 
+jest.doMock('expo-secure-store', () => ({
+  getItem: () => 'c0123456789abcdef0123456789',
+  setItem: () => {},
+  ALWAYS_THIS_DEVICE_ONLY: 4
+}))
+
 const networkBreadcrumbsPlugin = {
   load: () => () => {}
 }

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -2,6 +2,10 @@ const Device = require('expo-device')
 const Constants = require('expo-constants').default
 const { Dimensions, Platform } = require('react-native')
 const rnVersion = require('react-native/package.json').version
+const cuid = require('@bugsnag/cuid')
+const SecureStore = require('expo-secure-store')
+
+const DEVICE_ID_KEY = 'bugsnag-anonymous-id'
 
 module.exports = {
   load: client => {
@@ -21,8 +25,19 @@ module.exports = {
     // get the initial orientation
     updateOrientation()
 
+    const storeOptions = {
+      requireAuthentication: false,
+      keychainAccessible: SecureStore.ALWAYS_THIS_DEVICE_ONLY
+    }
+
+    let deviceId = SecureStore.getItem(DEVICE_ID_KEY, storeOptions)
+    if (!deviceId || !cuid.isCuid(deviceId)) {
+      deviceId = cuid()
+      SecureStore.setItem(DEVICE_ID_KEY, deviceId, storeOptions)
+    }
+
     const device = {
-      id: Constants.installationId,
+      id: deviceId,
       manufacturer: Device.manufacturer,
       model: Device.modelName,
       modelNumber: Device.modelId || undefined,

--- a/packages/plugin-expo-device/package.json
+++ b/packages/plugin-expo-device/package.json
@@ -16,14 +16,19 @@
   ],
   "author": "Bugsnag",
   "license": "MIT",
+  "dependencies": {
+    "@bugsnag/cuid": "^3.1.1"
+  },
   "devDependencies": {
     "@bugsnag/core": "^7.16.0",
     "expo-constants": "~16.0.1",
-    "expo-device": "~6.0.2"
+    "expo-device": "~6.0.2",
+    "expo-secure-store": "~13.0.1"
   },
   "peerDependencies": {
     "@bugsnag/core": "^7.0.0",
     "expo-constants": "~16.0.1",
-    "expo-device": "~6.0.2"
+    "expo-device": "~6.0.2",
+    "expo-secure-store": "~13.0.1"
   }
 }

--- a/packages/plugin-expo-device/test/device.test.js
+++ b/packages/plugin-expo-device/test/device.test.js
@@ -14,7 +14,6 @@ describe('plugin: expo device', () => {
 
     jest.doMock('expo-constants', () => ({
       default: {
-        installationId: '123',
         platform: { android: {} },
         expoConfig: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
@@ -37,6 +36,10 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'android', Version: ANDROID_API_LEVEL }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-secure-store', () => ({
+      getItem: () => 'c0123456789abcdef0123456789',
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
 
     const plugin = require('..')
 
@@ -64,8 +67,8 @@ describe('plugin: expo device', () => {
         })
         expect(r.events[0].metaData.device.isDevice).toBe(true)
         expect(r.events[0].metaData.device.appOwnership).toBe('standalone')
-        expect(r.events[0].device.id).toBe('123')
-        expect(r.events[0].user.id).toBe('123')
+        expect(r.events[0].device.id).toBe('c0123456789abcdef0123456789')
+        expect(r.events[0].user.id).toBe('c0123456789abcdef0123456789')
         done()
       },
       sendSession: () => {}
@@ -106,6 +109,10 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'ios' }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-secure-store', () => ({
+      getItem: () => 'c0123456789abcdef0123456789',
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
 
     const plugin = require('..')
 
@@ -167,6 +174,10 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'ios' }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-secure-store', () => ({
+      getItem: () => 'c0123456789abcdef0123456789',
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
 
     const plugin = require('..')
 
@@ -193,7 +204,6 @@ describe('plugin: expo device', () => {
 
     jest.doMock('expo-constants', () => ({
       default: {
-        installationId: '123',
         platform: { ios: {} },
         expoConfig: { sdkVersion: SDK_VERSION },
         expoVersion: EXPO_VERSION,
@@ -214,6 +224,10 @@ describe('plugin: expo device', () => {
       Platform: { OS: 'ios' }
     }))
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-secure-store', () => ({
+      getItem: () => 'c0123456789abcdef0123456789',
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
 
     const plugin = require('..')
 
@@ -282,6 +296,10 @@ describe('plugin: expo device', () => {
     }))
 
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+    jest.doMock('expo-secure-store', () => ({
+      getItem: () => 'c0123456789abcdef0123456789',
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
 
     const plugin = require('..')
 
@@ -308,6 +326,185 @@ describe('plugin: expo device', () => {
     d._set(1024, 100)
     c.notify(new Error('device testing'))
     d._set(100, 100)
+    c.notify(new Error('device testing'))
+  })
+
+  it('uses the stored device id if it exists', done => {
+    const REACT_NATIVE_VERSION = '0.57.1'
+    const SDK_VERSION = '32.3.0'
+    const EXPO_VERSION = '2.10.4'
+
+    jest.doMock('expo-constants', () => ({
+      default: {
+        platform: { ios: {} },
+        expoConfig: { sdkVersion: SDK_VERSION },
+        expoVersion: EXPO_VERSION,
+        appOwnership: 'expo'
+      }
+    }))
+    jest.doMock('expo-device', () => ({
+      manufacturer: 'Apple',
+      isDevice: true
+    }))
+    jest.doMock('react-native', () => ({
+      Dimensions: {
+        addEventListener: function () {},
+        get: function () {
+          return { width: 1024, height: 768 }
+        }
+      },
+      Platform: { OS: 'ios' }
+    }))
+    jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+
+    const getItem = jest.fn(() => 'c0123456789abcdef0123456789')
+    const setItem = jest.fn()
+    jest.doMock('expo-secure-store', () => ({
+      getItem,
+      setItem,
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
+
+    const plugin = require('..')
+
+    const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
+
+    expect(getItem).toHaveBeenCalledTimes(1)
+    expect(getItem).toHaveBeenCalledWith('bugsnag-anonymous-id', { keychainAccessible: 4, requireAuthentication: false })
+
+    expect(setItem).not.toHaveBeenCalled()
+
+    c._setDelivery(client => ({
+      sendEvent: (payload) => {
+        const r = JSON.parse(JSON.stringify(payload))
+        expect(r).toBeTruthy()
+        expect(r.events[0].device).toBeTruthy()
+        expect(r.events[0].device.id).toEqual('c0123456789abcdef0123456789')
+        done()
+      },
+      sendSession: () => {}
+
+    }))
+    c.notify(new Error('device testing'))
+  })
+
+  it('generates a new device id if none exists in storage', done => {
+    const REACT_NATIVE_VERSION = '0.57.1'
+    const SDK_VERSION = '32.3.0'
+    const EXPO_VERSION = '2.10.4'
+
+    jest.doMock('expo-constants', () => ({
+      default: {
+        platform: { ios: {} },
+        expoConfig: { sdkVersion: SDK_VERSION },
+        expoVersion: EXPO_VERSION,
+        appOwnership: 'expo'
+      }
+    }))
+    jest.doMock('expo-device', () => ({
+      manufacturer: 'Apple',
+      isDevice: true
+    }))
+    jest.doMock('react-native', () => ({
+      Dimensions: {
+        addEventListener: function () {},
+        get: function () {
+          return { width: 1024, height: 768 }
+        }
+      },
+      Platform: { OS: 'ios' }
+    }))
+    jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+
+    const getItem = jest.fn(() => null)
+    const setItem = jest.fn()
+    jest.doMock('expo-secure-store', () => ({
+      getItem,
+      setItem,
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
+
+    const plugin = require('..')
+
+    const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
+
+    expect(getItem).toHaveBeenCalledTimes(1)
+    expect(getItem).toHaveBeenCalledWith('bugsnag-anonymous-id', { keychainAccessible: 4, requireAuthentication: false })
+
+    expect(setItem).toHaveBeenCalledTimes(1)
+    expect(setItem).toHaveBeenCalledWith('bugsnag-anonymous-id', expect.any(String), { keychainAccessible: 4, requireAuthentication: false })
+
+    c._setDelivery(client => ({
+      sendEvent: (payload) => {
+        const r = JSON.parse(JSON.stringify(payload))
+        expect(r).toBeTruthy()
+        expect(r.events[0].device).toBeTruthy()
+        expect(r.events[0].device.id).toEqual(setItem.mock.calls[0][1])
+        done()
+      },
+      sendSession: () => {}
+
+    }))
+    c.notify(new Error('device testing'))
+  })
+
+  it('generates a new device id if the stored id is invalid', done => {
+    const REACT_NATIVE_VERSION = '0.57.1'
+    const SDK_VERSION = '32.3.0'
+    const EXPO_VERSION = '2.10.4'
+
+    jest.doMock('expo-constants', () => ({
+      default: {
+        platform: { ios: {} },
+        expoConfig: { sdkVersion: SDK_VERSION },
+        expoVersion: EXPO_VERSION,
+        appOwnership: 'expo'
+      }
+    }))
+    jest.doMock('expo-device', () => ({
+      manufacturer: 'Apple',
+      isDevice: true
+    }))
+    jest.doMock('react-native', () => ({
+      Dimensions: {
+        addEventListener: function () {},
+        get: function () {
+          return { width: 1024, height: 768 }
+        }
+      },
+      Platform: { OS: 'ios' }
+    }))
+    jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
+
+    const getItem = jest.fn(() => 'not a valid device id')
+    const setItem = jest.fn()
+    jest.doMock('expo-secure-store', () => ({
+      getItem,
+      setItem,
+      ALWAYS_THIS_DEVICE_ONLY: 4
+    }))
+
+    const plugin = require('..')
+
+    const c = new Client({ apiKey: 'api_key', plugins: [plugin] })
+
+    expect(getItem).toHaveBeenCalledTimes(1)
+    expect(getItem).toHaveBeenCalledWith('bugsnag-anonymous-id', { keychainAccessible: 4, requireAuthentication: false })
+
+    expect(setItem).toHaveBeenCalledTimes(1)
+    expect(setItem).toHaveBeenCalledWith('bugsnag-anonymous-id', expect.any(String), { keychainAccessible: 4, requireAuthentication: false })
+
+    c._setDelivery(client => ({
+      sendEvent: (payload) => {
+        const r = JSON.parse(JSON.stringify(payload))
+        expect(r).toBeTruthy()
+        expect(r.events[0].device).toBeTruthy()
+        expect(r.events[0].device.id).toEqual(setItem.mock.calls[0][1])
+        done()
+      },
+      sendSession: () => {}
+
+    }))
     c.notify(new Error('device testing'))
   })
 })


### PR DESCRIPTION
## Goal

Replaces the usage of `Constants.installationId` (which has been removed in SDK 51) with our own generated device id.

## Design

The device id is now generated using `@bugsnag/cuid` and is stored/retrieved synchronously on start using `expo-secure-store`.

This means there is now an additional peer dependency on `expo-secure-store` that must be installed alongside `@bugsnag/expo`

## Changeset

- added `@bugsnag/cuid` dependency and `expo-secure-store` peer dependency to `plugin-expo-device`
- replaced `Constants.installationId` with our own generated device id
- updated `bugsnag-expo-cli` to automatically install the `expo-secure-store` peer dependency
- added `UPGRADING.md`

## Testing

- added new unit tests
- reinstated skipped device.id tests and added new test to assert that the device id is persisted across app starts