### PR TITLE
Prevent crashes on Web

### DIFF
--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -1,6 +1,6 @@
 const Application = require('expo-application')
 const Constants = require('expo-constants').default
-const { AppState } = require('react-native')
+const { AppState, Platform } = require('react-native')
 
 const appStart = new Date()
 
@@ -19,9 +19,9 @@ module.exports = {
     let bundleVersion, versionCode
 
     if (Constants.appOwnership !== 'expo') {
-      if (Constants.platform.ios) {
+      if (Platform.OS === 'ios') {
         bundleVersion = Application.nativeBuildVersion
-      } else if (Constants.platform.android) {
+      } else if (Platform.OS === 'android') {
         versionCode = Application.nativeBuildVersion
       }
     }

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -4,7 +4,8 @@ jest.mock('react-native', () => ({
   AppState: {
     addEventListener: jest.fn(),
     currentState: 'active'
-  }
+  },
+  Platform: { OS: 'android' }
 }))
 
 describe('plugin: expo app', () => {
@@ -66,6 +67,13 @@ describe('plugin: expo app', () => {
         appOwnership: null
       }
     }))
+    jest.doMock('react-native', () => ({
+      AppState: {
+        addEventListener: jest.fn(),
+        currentState: 'active'
+      },
+      Platform: { OS: 'ios' }
+    }))
 
     const plugin = require('..')
 
@@ -109,7 +117,8 @@ describe('plugin: expo app', () => {
     }))
 
     jest.doMock('react-native', () => ({
-      AppState
+      AppState,
+      Platform: { OS: 'ios' }
     }))
 
     const plugin = require('..')

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -50,7 +50,7 @@ module.exports = {
         reactNative: rnVersion,
         expoApp: Constants.expoVersion,
         expoSdk: Constants.expoConfig?.sdkVersion,
-        androidApiLevel: Constants.platform.android ? String(Platform.Version) : undefined
+        androidApiLevel: Platform.OS === 'android' ? String(Platform.Version) : undefined
       },
       totalMemory: Device.totalMemory
     }

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -25,15 +25,18 @@ module.exports = {
     // get the initial orientation
     updateOrientation()
 
-    const storeOptions = {
-      requireAuthentication: false,
-      keychainAccessible: SecureStore.ALWAYS_THIS_DEVICE_ONLY
-    }
+    let deviceId
+    if (Platform.OS === 'android' || Platform.OS === 'ios') {
+      const storeOptions = {
+        requireAuthentication: false,
+        keychainAccessible: SecureStore.ALWAYS_THIS_DEVICE_ONLY
+      }
 
-    let deviceId = SecureStore.getItem(DEVICE_ID_KEY, storeOptions)
-    if (!deviceId || !cuid.isCuid(deviceId)) {
-      deviceId = cuid()
-      SecureStore.setItem(DEVICE_ID_KEY, deviceId, storeOptions)
+      deviceId = SecureStore.getItem(DEVICE_ID_KEY, storeOptions)
+      if (!deviceId || !cuid.isCuid(deviceId)) {
+        deviceId = cuid()
+        SecureStore.setItem(DEVICE_ID_KEY, deviceId, storeOptions)
+      }
     }
 
     const device = {


### PR DESCRIPTION
## Goal

Prevent apps from crashing on web platform:
- Adds a platform check around the usage of `expo-secure-store` to get/set the device id (which causes a crash on web). This fixes the crash reported in #183.
- Replaces usage of `Constants.platform` (which is undefined on web) with the React Native Platform API

## Design

Although Web isn't officially supported, this should at least prevent the app from crashing. However this means that device ids will no longer be reported on web, so user stability scores will not work.

## Testing

- Relied on existing unit and CI tests to ensure that device IDs are still generated and persisted on Android and iOS
- Manually tested on web