### PR TITLE
Fix Expo v51 test fixture build

### DIFF
--- a/features/fixtures/test-app/app.json
+++ b/features/fixtures/test-app/app.json
@@ -20,7 +20,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.bugsnag.expo.testfixture",
+      "bundleIdentifier": "com.bugsnag.expo.fixture",
       "buildNumber": "1",
       "infoPlist": {
         "NSAppTransportSecurity": {

--- a/features/scripts/build-common.sh
+++ b/features/scripts/build-common.sh
@@ -26,7 +26,7 @@ sed -i '' "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
 
 ./run-bugsnag-expo-cli-install
 
-cp $EXPO_UNIVERSAL_CREDENTIALS_DIR/* .
+cp $EXPO_CREDENTIALS_DIR/* .
 
 echo "Common setup complete"
 

--- a/features/scripts/build-ios.sh
+++ b/features/scripts/build-ios.sh
@@ -6,6 +6,7 @@ set -e
 if [[ -z ${EAS_LOCAL_BUILD_WORKINGDIR:-} ]]; then
   EAS_LOCAL_BUILD_WORKINGDIR=$BUILDKITE_BUILD_CHECKOUT_PATH/features/fixtures/build
   export EAS_LOCAL_BUILD_WORKINGDIR
+  export EAS_LOCAL_BUILD_SKIP_CLEANUP=1
 fi
 
 pushd features/fixtures/test-app


### PR DESCRIPTION
## Goal

Fix the Expo v51 test fixture build.

## Supporting changes to our build infrastructure were also needed to make this work.

## Changeset

- Bundle Id updated to avoid a clash with our old Apple account.
- Environment set to stop Expo clearing away working files - making it easier to debug future issues.
- Environment variable name harmonised with infrastructure changes.

## Testing

Covered by CI.