### PR TITLE
Release v51.0.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "opensource"
+
 steps:
   #
   # License audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [51.0.1] - 2024-08-29
+
+### Fixed
+
+- (plugin-expo-device) Do not use expo-secure-store on unsupported platforms [#185](https://github.com/bugsnag/bugsnag-expo/pull/185)
+- (plugin-expo-device, plugin-expo-app) Replace Constants.platform usage with Platform API [#185](https://github.com/bugsnag/bugsnag-expo/pull/185)
+
 ## [51.0.0] - 2024-05-16
 
 This release adds support for Expo 51.

--- a/features/fixtures/test-app/app.json
+++ b/features/fixtures/test-app/app.json
@@ -20,7 +20,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.bugsnag.expo.testfixture",
+      "bundleIdentifier": "com.bugsnag.expo.fixture",
       "buildNumber": "1",
       "infoPlist": {
         "NSAppTransportSecurity": {

--- a/features/scripts/build-common.sh
+++ b/features/scripts/build-common.sh
@@ -26,7 +26,7 @@ sed -i '' "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
 
 ./run-bugsnag-expo-cli-install
 
-cp $EXPO_UNIVERSAL_CREDENTIALS_DIR/* .
+cp $EXPO_CREDENTIALS_DIR/* .
 
 echo "Common setup complete"
 

--- a/features/scripts/build-ios.sh
+++ b/features/scripts/build-ios.sh
@@ -6,6 +6,7 @@ set -e
 if [[ -z ${EAS_LOCAL_BUILD_WORKINGDIR:-} ]]; then
   EAS_LOCAL_BUILD_WORKINGDIR=$BUILDKITE_BUILD_CHECKOUT_PATH/features/fixtures/build
   export EAS_LOCAL_BUILD_WORKINGDIR
+  export EAS_LOCAL_BUILD_SKIP_CLEANUP=1
 fi
 
 pushd features/fixtures/test-app

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -1,6 +1,6 @@
 const Application = require('expo-application')
 const Constants = require('expo-constants').default
-const { AppState } = require('react-native')
+const { AppState, Platform } = require('react-native')
 
 const appStart = new Date()
 
@@ -19,9 +19,9 @@ module.exports = {
     let bundleVersion, versionCode
 
     if (Constants.appOwnership !== 'expo') {
-      if (Constants.platform.ios) {
+      if (Platform.OS === 'ios') {
         bundleVersion = Application.nativeBuildVersion
-      } else if (Constants.platform.android) {
+      } else if (Platform.OS === 'android') {
         versionCode = Application.nativeBuildVersion
       }
     }

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -4,7 +4,8 @@ jest.mock('react-native', () => ({
   AppState: {
     addEventListener: jest.fn(),
     currentState: 'active'
-  }
+  },
+  Platform: { OS: 'android' }
 }))
 
 describe('plugin: expo app', () => {
@@ -66,6 +67,13 @@ describe('plugin: expo app', () => {
         appOwnership: null
       }
     }))
+    jest.doMock('react-native', () => ({
+      AppState: {
+        addEventListener: jest.fn(),
+        currentState: 'active'
+      },
+      Platform: { OS: 'ios' }
+    }))
 
     const plugin = require('..')
 
@@ -109,7 +117,8 @@ describe('plugin: expo app', () => {
     }))
 
     jest.doMock('react-native', () => ({
-      AppState
+      AppState,
+      Platform: { OS: 'ios' }
     }))
 
     const plugin = require('..')

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -50,7 +50,7 @@ module.exports = {
         reactNative: rnVersion,
         expoApp: Constants.expoVersion,
         expoSdk: Constants.expoConfig?.sdkVersion,
-        androidApiLevel: Constants.platform.android ? String(Platform.Version) : undefined
+        androidApiLevel: Platform.OS === 'android' ? String(Platform.Version) : undefined
       },
       totalMemory: Device.totalMemory
     }

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -25,15 +25,18 @@ module.exports = {
     // get the initial orientation
     updateOrientation()
 
-    const storeOptions = {
-      requireAuthentication: false,
-      keychainAccessible: SecureStore.ALWAYS_THIS_DEVICE_ONLY
-    }
+    let deviceId
+    if (Platform.OS === 'android' || Platform.OS === 'ios') {
+      const storeOptions = {
+        requireAuthentication: false,
+        keychainAccessible: SecureStore.ALWAYS_THIS_DEVICE_ONLY
+      }
 
-    let deviceId = SecureStore.getItem(DEVICE_ID_KEY, storeOptions)
-    if (!deviceId || !cuid.isCuid(deviceId)) {
-      deviceId = cuid()
-      SecureStore.setItem(DEVICE_ID_KEY, deviceId, storeOptions)
+      deviceId = SecureStore.getItem(DEVICE_ID_KEY, storeOptions)
+      if (!deviceId || !cuid.isCuid(deviceId)) {
+        deviceId = cuid()
+        SecureStore.setItem(DEVICE_ID_KEY, deviceId, storeOptions)
+      }
     }
 
     const device = {


### PR DESCRIPTION
### Fixed

- (plugin-expo-device) Do not use expo-secure-store on unsupported platforms [#185](https://github.com/bugsnag/bugsnag-expo/pull/185)
- (plugin-expo-device, plugin-expo-app) Replace Constants.platform usage with Platform API [#185](https://github.com/bugsnag/bugsnag-expo/pull/185)