### PR TITLE
[v49] Use commit id for BugSnag version override

### DIFF
--- a/features/fixtures/test-app/set-bugsnag-js-overrides
+++ b/features/fixtures/test-app/set-bugsnag-js-overrides
@@ -30,7 +30,7 @@ version = Dir.mktmpdir("bugsnag-js") do |directory|
     }
 
     Tempfile.create(["get-bugsnag-js-version", ".js"], directory) do |file|
-      file.write("console.log(require('./scripts/common').determineVersion())")
+      file.write("console.log(require('./scripts/common').getCommitId())")
       file.close # close the file to flush our changes to disk
 
       output, status = Open3.capture2(env, "node #{file.path}", unsetenv_others: true)


### PR DESCRIPTION
## Goal

To ensure we always use the correct version of the Bugsnag notifier for the end to end fixtures

## Changeset

Use the git commit id (published as dist tag) when installing the notifier 

## Testing

Covered by full CI fun