### PR TITLE
Remove nativeVersionCode and nativeBundleVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 
-- (delivery-expo) Changed "Redeliveryloop error" message to "An error occurred attempting to redeliver a payload" [#193](https://github.com/bugsnag/bugsnag-expo/pull/193)
+- (delivery-expo) Change "Redeliveryloop error" message to "An error occurred attempting to redeliver a payload" [#193](https://github.com/bugsnag/bugsnag-expo/pull/193)
+- (plugin-expo-app) Remove duplicate `nativeBundleVersion` and `nativeVersionCode` app metadata [#204](https://github.com/bugsnag/bugsnag-expo/pull/204)
 
 ## [51.0.1] - 2024-08-29
 

--- a/packages/plugin-expo-app/app.js
+++ b/packages/plugin-expo-app/app.js
@@ -52,8 +52,6 @@ module.exports = {
 
       event.app.versionCode = versionCode
       event.app.bundleVersion = bundleVersion
-
-      event.addMetadata('app', { nativeBundleVersion: bundleVersion, nativeVersionCode: versionCode })
     }, true)
   }
 }

--- a/packages/plugin-expo-app/test/app.test.js
+++ b/packages/plugin-expo-app/test/app.test.js
@@ -13,7 +13,7 @@ describe('plugin: expo app', () => {
     jest.resetModules()
   })
 
-  it('should record nativeVersionCode and versionCode on android', done => {
+  it('should record versionCode on android', done => {
     const VERSION_CODE = '1.0'
 
     jest.doMock('expo-application', () => ({ nativeBuildVersion: VERSION_CODE }))
@@ -41,7 +41,6 @@ describe('plugin: expo app', () => {
       sendEvent: (payload) => {
         const r = JSON.parse(JSON.stringify(payload))
         expect(r).toBeTruthy()
-        expect(r.events[0].metaData.app.nativeVersionCode).toBe(VERSION_CODE)
         expect(r.events[0].app.versionCode).toBe(VERSION_CODE)
         done()
       },
@@ -54,7 +53,7 @@ describe('plugin: expo app', () => {
     c.notify(new Error('flip'))
   })
 
-  it('should record nativeBundleVersion and bundleVersion on ios', done => {
+  it('should record bundleVersion on ios', done => {
     const BUNDLE_VERSION = '1.0'
 
     jest.doMock('expo-application', () => ({ nativeBuildVersion: BUNDLE_VERSION }))
@@ -89,7 +88,6 @@ describe('plugin: expo app', () => {
       sendEvent: (payload) => {
         const r = JSON.parse(JSON.stringify(payload))
         expect(r).toBeTruthy()
-        expect(r.events[0].metaData.app.nativeBundleVersion).toBe(BUNDLE_VERSION)
         expect(r.events[0].app.bundleVersion).toBe(BUNDLE_VERSION)
         done()
       },


### PR DESCRIPTION
## Goal

Remove `nativeVersionCode` and `nativeBundleVersion` from `plugin-expo-app`

## Testing

Remove assertions from unit tests