### PR TITLE
Allow e2e tests to fallback to using Appium driver.close.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,6 +55,7 @@ steps:
           - --app=build/output.apk
           - --farm=bs
           - --device=ANDROID_12
+          - --appium-version=1.22.0
           - --a11y-locator
           - --retry=2
       test-collector#v1.10.2:

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '~> 1.14.3'
 gem 'fastlane'
+gem 'xcpretty', '~> 0.4.1'
 
 gem 'bugsnag-maze-runner', '~>9.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.3.1)
-    fastlane (2.220.0)
+    fastlane (2.227.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -206,6 +206,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       faraday_middleware (~> 1.0)
       fastimage (>= 2.1.0, < 3.0.0)
+      fastlane-sirp (>= 1.0.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-apis-androidpublisher_v3 (~> 0.3)
       google-apis-playcustomapp_v1 (~> 0.1)
@@ -229,8 +230,10 @@ GEM
       tty-spinner (>= 0.8.0, < 1.0.0)
       word_wrap (~> 1.0.0)
       xcodeproj (>= 1.13.0, < 2.0.0)
-      xcpretty (~> 0.3.0)
+      xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
+    fastlane-sirp (1.0.0)
+      sysrandom (~> 1.0)
     faye-websocket (0.11.3)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
@@ -327,7 +330,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.2)
     rexml (3.2.6)
-    rouge (2.0.7)
+    rouge (3.28.0)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -348,6 +351,7 @@ GEM
     simpleidn (0.2.3)
     sys-uname (1.3.0)
       ffi (~> 1.1)
+    sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -379,19 +383,21 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    xcpretty (0.3.0)
-      rouge (~> 2.0.7)
+    xcpretty (0.4.1)
+      rouge (~> 3.28.0)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
 
 DEPENDENCIES
   bugsnag-maze-runner (~> 9.0)
   cocoapods (~> 1.14.3)
   fastlane
+  xcpretty (~> 0.4.1)
 
 BUNDLED WITH
    2.4.8


### PR DESCRIPTION
## Goal

Allow e2e tests to fallback to using Appium driver.close.

## Design

The Android e2e tests will use Appium 1.22 anyway as that's the current default on BrowserStack, but setting it explicitly will mean that Maze Runner will fall back to using driver.close if terminate_app fails (as it frequently does at present).

## Changeset

I've also fixed the IPA build by pinning xcpretty.

## Testing

Covered by CI.