### PR TITLE
Explicitly set Appium version for Android

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,6 +56,7 @@ steps:
           - --farm=bs
           - --device=ANDROID_15
           - --a11y-locator
+          - --appium-version=1.22.0
           - --fail-fast
           - --retry=2
           - --order=random


### PR DESCRIPTION
## Goal

Allow e2e tests to fallback to using Appium driver.close.

## Design

The Android e2e tests will use Appium 1.22 anyway as that's the current default on BrowserStack, but setting it explicitly will mean that Maze Runner will fall back to using driver.close if terminate_app fails (as it frequently does at present).

## Testing

Covered by CI.