### PR TITLE
update cli entry file detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- (expo-cli) Support Expo Router and React Navigation entryfiles [#239](https://github.com/bugsnag/bugsnag-expo/pull/239)
+
 ## [55.0.0] - 2026-03-26
 
 This release adds support for Expo 55

--- a/packages/expo-cli/commands/insert.js
+++ b/packages/expo-cli/commands/insert.js
@@ -4,7 +4,7 @@ const { onCancel } = require('../lib/utils')
 const { blue, yellow } = require('kleur')
 
 module.exports = async (argv, globalOpts) => {
-  const message = `The following Bugsnag initialization lines will be added to App.js. Is this ok?
+  const message = `The following Bugsnag initialization lines will be added to your application's entry file. Is this ok?
 
   ${(await insert.getCode(globalOpts['project-root'])).replace('\n', '\n  ')}
   `
@@ -15,7 +15,7 @@ module.exports = async (argv, globalOpts) => {
     message,
     initial: true
   }, { onCancel })
-  console.log(blue('> Inserting Bugsnag initialization into App.js'))
+  console.log(blue('> Inserting Bugsnag initialization into the entry file'))
   if (res.insert) {
     const msg = await insert(globalOpts['project-root'])
     if (msg) console.log(yellow(`  ${msg}`))

--- a/packages/expo-cli/lib/insert.js
+++ b/packages/expo-cli/lib/insert.js
@@ -1,38 +1,36 @@
 const { join } = require('path')
-const { readFile, writeFile, existsSync } = require('fs')
+const { readFile, writeFile } = require('fs')
 const { promisify } = require('util')
 const { detectInstalledVersion } = require('./detect-installed')
+const { findAppEntry } = require('./utils')
 const semver = require('semver')
 
 const importRe = /from ["']@bugsnag\/expo["']/
 const requireRe = /require\(["']@bugsnag\/expo["']\)/
+const entrypoints = ['App.ts',
+  'App.tsx',
+  'App.js',
+  'App.jsx',
+  join('src', 'App.ts'),
+  join('src', 'App.tsx'),
+  join('src', 'App.js'),
+  join('src', 'App.jsx'),
+  join('app', '_layout.tsx')
+]
 
 module.exports = async (projectRoot) => {
-  function checkFileExists (filename) {
-    const appPath = join(projectRoot, filename)
-    return existsSync(appPath)
+  // find app entry file
+  const appPath = findAppEntry(projectRoot, entrypoints)
+  if (!appPath) {
+    throw new Error(`Could not find app entry file. Searched: ${entrypoints.join(', ')}`)
   }
-
-  const writeBugsnagImport = async (filename) => {
-    // check if import statement has already been added and return
-    const appPath = join(projectRoot, filename)
-    const app = await promisify(readFile)(appPath, 'utf8')
-    if (importRe.test(app) || requireRe.test(app)) {
-      return `@bugsnag/expo is already imported in ${filename}`
-    }
-    // write to file
-    await promisify(writeFile)(appPath, `${await getCode(projectRoot)}\n${app}`, 'utf8')
+  // check if import statement has already been added and return
+  const app = await promisify(readFile)(appPath, 'utf8')
+  if (importRe.test(app) || requireRe.test(app)) {
+    return `@bugsnag/expo is already imported in ${appPath}`
   }
-
-  if (checkFileExists('App.ts')) {
-    return await writeBugsnagImport('App.ts')
-  } else if (checkFileExists('App.tsx')) {
-    return await writeBugsnagImport('App.tsx')
-  } else if (checkFileExists('App.js')) {
-    return await writeBugsnagImport('App.js')
-  } else {
-    throw new Error(`Couldn’t find App.js or App.ts(x) in "${projectRoot}". Is this the root of your Expo project?`)
-  }
+  // write to file
+  await promisify(writeFile)(appPath, `${await getCode(projectRoot)}\n${app}`, 'utf8')
 }
 
 const code = {

--- a/packages/expo-cli/lib/test/fixtures/app-dir-entry/app.json
+++ b/packages/expo-cli/lib/test/fixtures/app-dir-entry/app.json
@@ -1,0 +1,48 @@
+{
+  "expo": {
+    "name": "v54x",
+    "slug": "v54x",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/images/icon.png",
+    "scheme": "v54x",
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": true,
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#E6F4FE",
+        "foregroundImage": "./assets/images/android-icon-foreground.png",
+        "backgroundImage": "./assets/images/android-icon-background.png",
+        "monochromeImage": "./assets/images/android-icon-monochrome.png"
+      },
+      "edgeToEdgeEnabled": true,
+      "predictiveBackGestureEnabled": false
+    },
+    "web": {
+      "output": "static",
+      "favicon": "./assets/images/favicon.png"
+    },
+    "plugins": [
+      "expo-router",
+      [
+        "expo-splash-screen",
+        {
+          "image": "./assets/images/splash-icon.png",
+          "imageWidth": 200,
+          "resizeMode": "contain",
+          "backgroundColor": "#ffffff",
+          "dark": {
+            "backgroundColor": "#000000"
+          }
+        }
+      ]
+    ],
+    "experiments": {
+      "typedRoutes": true,
+      "reactCompiler": true
+    }
+  }
+}

--- a/packages/expo-cli/lib/test/fixtures/app-dir-entry/app/_layout.tsx
+++ b/packages/expo-cli/lib/test/fixtures/app-dir-entry/app/_layout.tsx
@@ -1,0 +1,24 @@
+import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { Stack } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import 'react-native-reanimated';
+
+import { useColorScheme } from '@/hooks/use-color-scheme';
+
+export const unstable_settings = {
+  anchor: '(tabs)',
+};
+
+export default function RootLayout() {
+  const colorScheme = useColorScheme();
+
+  return (
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+      </Stack>
+      <StatusBar style="auto" />
+    </ThemeProvider>
+  );
+}

--- a/packages/expo-cli/lib/test/fixtures/app-dir-entry/package.json
+++ b/packages/expo-cli/lib/test/fixtures/app-dir-entry/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "v54x",
+  "main": "expo-router/entry",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "expo start",
+    "reset-project": "node ./scripts/reset-project.js",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "expo lint"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
+    "@react-navigation/bottom-tabs": "^7.4.0",
+    "@react-navigation/elements": "^2.6.3",
+    "@react-navigation/native": "^7.1.8",
+    "expo": "~54.0.29",
+    "expo-constants": "~18.0.12",
+    "expo-font": "~14.0.10",
+    "expo-haptics": "~15.0.8",
+    "expo-image": "~3.0.11",
+    "expo-linking": "~8.0.10",
+    "expo-router": "~6.0.19",
+    "expo-splash-screen": "~31.0.12",
+    "expo-status-bar": "~3.0.9",
+    "expo-symbols": "~1.0.8",
+    "expo-system-ui": "~6.0.9",
+    "expo-web-browser": "~15.0.10",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-native": "0.81.5",
+    "react-native-gesture-handler": "~2.28.0",
+    "react-native-worklets": "0.5.1",
+    "react-native-reanimated": "~4.1.1",
+    "react-native-safe-area-context": "~5.6.0",
+    "react-native-screens": "~4.16.0",
+    "react-native-web": "~0.21.0"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "typescript": "~5.9.2",
+    "eslint": "^9.25.0",
+    "eslint-config-expo": "~10.0.0"
+  },
+  "private": true
+}

--- a/packages/expo-cli/lib/test/fixtures/src-dir-entry/app.json
+++ b/packages/expo-cli/lib/test/fixtures/src-dir-entry/app.json
@@ -1,0 +1,34 @@
+{
+  "expo": {
+    "name": "v54xrnav",
+    "slug": "v54xrnav",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "src/assets/images/icon.png",
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": true,
+    "scheme": "v54xrnav",
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "src/assets/images/adaptive-icon.png",
+        "backgroundColor": "#ffffff"
+      }
+    },
+    "web": {
+      "favicon": "src/assets/images/favicon.png"
+    },
+    "plugins": [
+      "expo-asset",
+      [
+        "expo-splash-screen",
+        {
+          "backgroundColor": "#ffffff",
+          "image": "src/assets/images/splash-icon.png"
+        }
+      ]
+    ]
+  }
+}

--- a/packages/expo-cli/lib/test/fixtures/src-dir-entry/package.json
+++ b/packages/expo-cli/lib/test/fixtures/src-dir-entry/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "v54xrnav",
+  "version": "1.0.0",
+  "main": "index.tsx",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "reset-project": "node ./src/scripts/reset-project.js"
+  },
+  "dependencies": {
+    "@expo/metro-runtime": "~6.1.0",
+    "@expo/vector-icons": "^15.0.2",
+    "@react-navigation/bottom-tabs": "^7.4.0",
+    "@react-navigation/elements": "^2.6.3",
+    "@react-navigation/native": "^7.1.8",
+    "@react-navigation/native-stack": "^7.3.16",
+    "expo": "^54.0.1",
+    "expo-asset": "~12.0.3",
+    "expo-blur": "~15.0.2",
+    "expo-constants": "~18.0.3",
+    "expo-font": "~14.0.2",
+    "expo-haptics": "~15.0.2",
+    "expo-image": "~3.0.2",
+    "expo-linking": "~8.0.2",
+    "expo-splash-screen": "~31.0.3",
+    "expo-status-bar": "~3.0.3",
+    "expo-symbols": "~1.0.2",
+    "expo-web-browser": "~15.0.2",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-native": "0.81.4",
+    "react-native-gesture-handler": "~2.28.0",
+    "react-native-reanimated": "~4.1.0",
+    "react-native-safe-area-context": "~5.6.0",
+    "react-native-screens": "~4.16.0",
+    "react-native-web": "^0.21.0",
+    "react-native-worklets": "0.5.1"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "eslint": "^9.25.0",
+    "eslint-config-expo": "~10.0.0",
+    "typescript": "~5.9.2"
+  },
+  "private": true
+}

--- a/packages/expo-cli/lib/test/fixtures/src-dir-entry/src/App.tsx
+++ b/packages/expo-cli/lib/test/fixtures/src-dir-entry/src/App.tsx
@@ -1,0 +1,50 @@
+import 'react-native-reanimated';
+import { DarkTheme, DefaultTheme } from '@react-navigation/native';
+import { useFonts } from 'expo-font';
+import * as SplashScreen from 'expo-splash-screen';
+import * as React from 'react';
+import { useColorScheme } from 'react-native';
+
+import { Colors } from './constants/Colors';
+import { Navigation } from './navigation';
+
+SplashScreen.preventAutoHideAsync();
+
+export function App() {
+  const colorScheme = useColorScheme();
+  const [loaded] = useFonts({
+    SpaceMono: require('./assets/fonts/SpaceMono-Regular.ttf'),
+  });
+
+  if (!loaded) {
+    // Async font loading only occurs in development.
+    return null;
+  }
+
+  const theme =
+    colorScheme === 'dark'
+      ? {
+          ...DarkTheme,
+          colors: { ...DarkTheme.colors, primary: Colors[colorScheme ?? 'light'].tint },
+        }
+      : {
+          ...DefaultTheme,
+          colors: { ...DefaultTheme.colors, primary: Colors[colorScheme ?? 'light'].tint },
+        };
+
+  return (
+    <Navigation
+      theme={theme}
+      linking={{
+        enabled: 'auto',
+        prefixes: [
+          // Change the scheme to match your app's scheme defined in app.json
+          'helloworld://',
+        ],
+      }}
+      onReady={() => {
+        SplashScreen.hideAsync();
+      }}
+    />
+  );
+}

--- a/packages/expo-cli/lib/test/insert.test.js
+++ b/packages/expo-cli/lib/test/insert.test.js
@@ -151,4 +151,24 @@ describe('expo-cli: insert', () => {
       expect(appJs).toMatch(/^import Bugsnag from '@bugsnag\/expo';\sBugsnag\.start\(\);\s/)
     })
   })
+
+  it('detects the entrypoint in an Expo Router `app` directory', async () => {
+    await withFixture('app-dir-entry', async (projectRoot) => {
+      const msg = await insert(projectRoot)
+      expect(msg).toBe(undefined)
+
+      const appJs = await readFile(`${projectRoot}/app/_layout.tsx`, 'utf8')
+      expect(appJs).toMatch(/^import Bugsnag from '@bugsnag\/expo';\sBugsnag.start\(\);\s/)
+    })
+  })
+
+  it('detects the entrypoint in an React Navigation `src` directory', async () => {
+    await withFixture('src-dir-entry', async (projectRoot) => {
+      const msg = await insert(projectRoot)
+      expect(msg).toBe(undefined)
+
+      const appJs = await readFile(`${projectRoot}/src/App.tsx`, 'utf8')
+      expect(appJs).toMatch(/^import Bugsnag from '@bugsnag\/expo';\sBugsnag.start\(\);\s/)
+    })
+  })
 })

--- a/packages/expo-cli/lib/test/insert.test.js
+++ b/packages/expo-cli/lib/test/insert.test.js
@@ -104,7 +104,7 @@ describe('expo-cli: insert', () => {
 
   it('should provide a reasonable error when there is no App.js or App.ts/tsx', async () => {
     await withFixture('empty-00', async (projectRoot) => {
-      await expect(insert(projectRoot)).rejects.toThrow(/^Couldn’t find App\.js or App\.ts\(x\) in/)
+      await expect(insert(projectRoot)).rejects.toThrow(/^Could not find app entry file\. Searched:.*/)
     })
   })
 

--- a/packages/expo-cli/lib/utils.js
+++ b/packages/expo-cli/lib/utils.js
@@ -1,6 +1,6 @@
 const process = require('process')
 const { promisify } = require('util')
-const { readFile } = require('fs')
+const { readFile, existsSync } = require('fs')
 const { join } = require('path')
 
 // cache dependencies to avoid potentially parsing package.json multiple times
@@ -22,6 +22,21 @@ async function getDependencies (directory) {
   return cachedDependencies.get(directory)
 }
 
+function checkFileExists (projectRoot, filename) {
+  const appPath = join(projectRoot, filename)
+  return existsSync(appPath)
+}
+
+function findAppEntry (projectRoot, filenames) {
+  for (const filename of filenames) {
+    const appPath = join(projectRoot, filename)
+    if (existsSync(appPath)) {
+      return appPath
+    }
+  }
+  return null
+}
+
 function resolvePackageName (packageName, version) {
   if (version === 'latest') {
     return packageName
@@ -34,6 +49,8 @@ module.exports = {
   onCancel: () => process.exit(),
   getDependencies,
   resolvePackageName,
+  checkFileExists,
+  findAppEntry,
   DEPENDENCIES: [
     '@react-native-community/netinfo',
     'expo-application',


### PR DESCRIPTION
## Goal

Currently the code insertion process for the CLI doesn't recognize the entrypoints for apps using React Navigation or Expo Router. This PR updates and extends the logic, so it covers a larger set of possible entryfiles

## Changeset

- Extracted entrypoint detection to an `utils` file
- Added a larger set of entrypoints the CLI searches to insert code into

## Testing

Updated unit tests to reflect the CLI changes. All changes passed unit tests and were tested locally.