### PR TITLE
Set version override for request-tracker package in test fixture builds

### DIFF
--- a/features/fixtures/test-app/set-bugsnag-js-overrides
+++ b/features/fixtures/test-app/set-bugsnag-js-overrides
@@ -65,6 +65,7 @@ final_json = File.open("package.json") do |file|
     "@bugsnag/plugin-react-native-global-error-handler" => version,
     "@bugsnag/plugin-react-native-orientation-breadcrumbs" => version,
     "@bugsnag/plugin-react-native-unhandled-rejection" => version,
+    "@bugsnag/request-tracker" => version,
   })
 
   JSON.pretty_generate(package_json)


### PR DESCRIPTION
## Goal

bugsnag-js has added a new package `@bugsnag/request-tracker` which is a dependency of `@bugsnag/plugin-network-breadcrumbs`. This PR adds a version override for the new package to test fixture builds triggered from the JS repo to make sure that the locally published package is used in the test run.

## Testing

Network breadcrumbs tests are currently failing due to a bug in `@bugsnag/request-tracker`, so we'll need to force-merge this PR to unblock CI from the JS pipeline