### PR TITLE
Fix JS pipeline overrides (v53)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,7 +59,6 @@ steps:
           - --appium-version=1.22.0
           - --fail-fast
           - --retry=2
-          - --order=random
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
@@ -90,7 +89,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --order=random
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
@@ -121,7 +119,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --order=random
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
@@ -152,7 +149,6 @@ steps:
           - --a11y-locator
           - --fail-fast
           - --retry=2
-          - --order=random
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"

--- a/features/scripts/build-common.sh
+++ b/features/scripts/build-common.sh
@@ -10,6 +10,9 @@ git clean -xfdf
 # And the yarn cache is clean
 yarn cache clean --all
 
+# set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
+./features/scripts/set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT
+
 # Install repo dependencies
 yarn install
 
@@ -20,9 +23,6 @@ cd features/fixtures/test-app
 
 # Set EAS Project ID
 sed -i '' "s/EXPO_EAS_PROJECT_ID/$EXPO_EAS_PROJECT_ID/g" app.json
-
-# set bugsnag-js override versions if this build was triggered from the bugsnag-js repo
-./set-bugsnag-js-overrides $BUGSNAG_JS_BRANCH $BUGSNAG_JS_COMMIT
 
 ./run-bugsnag-expo-cli-install
 

--- a/features/scripts/set-bugsnag-js-overrides
+++ b/features/scripts/set-bugsnag-js-overrides
@@ -30,7 +30,7 @@ version = Dir.mktmpdir("bugsnag-js") do |directory|
     }
 
     Tempfile.create(["get-bugsnag-js-version", ".js"], directory) do |file|
-      file.write("console.log(require('./scripts/common').getCommitId())")
+      file.write("console.log(require('./scripts/common').determineVersion())")
       file.close # close the file to flush our changes to disk
 
       output, status = Open3.capture2(env, "node #{file.path}", unsetenv_others: true)
@@ -57,6 +57,19 @@ final_json = File.open("package.json") do |file|
 
   package_json["overrides"] ||= {}
   package_json["overrides"].merge!({
+    "@bugsnag/core" => version,
+    "@bugsnag/plugin-browser-session" => version,
+    "@bugsnag/plugin-console-breadcrumbs" => version,
+    "@bugsnag/plugin-network-breadcrumbs" => version,
+    "@bugsnag/plugin-react" => version,
+    "@bugsnag/plugin-react-native-global-error-handler" => version,
+    "@bugsnag/plugin-react-native-orientation-breadcrumbs" => version,
+    "@bugsnag/plugin-react-native-unhandled-rejection" => version,
+    "@bugsnag/request-tracker" => version,
+  })
+
+  package_json["resolutions"] ||= {}
+  package_json["resolutions"].merge!({
     "@bugsnag/core" => version,
     "@bugsnag/plugin-browser-session" => version,
     "@bugsnag/plugin-console-breadcrumbs" => version,


### PR DESCRIPTION
## Goal

When a build is triggered from a bugsnag-js pipeline build, the `set-bugsnag-js-overrides` script adds package overrides to the test fixture's `package.json`  so that bugsnag dependencies are installed from artifactory for that specific build. However that script currently does not work as intended for several reasons:

- The script adds the version overrides to the `overrides` field, but expo fixture builds use yarn, which uses the `resolutions` field
- The overrides are added to the test fixture's `package.json` - but EAS build treats the test fixture as a workspace in the monorepo, and for workspaces yarn `resolutions` must be added to the project root
- The version overrides are set to the bugsnag-js commit hash (this is the `dist-tag` that they are published to artifactory with), however yarn resolutions don't support `dist-tag`s

## Design

Updated the script to use address these problems:

- Adds version overrides to both `overrides` and `resolutions` fields
- Uses the repo root `package.json` instead of the test fixture's
- Uses the full version for the override instead of the commit hash/dist-tag

I've also removed the `--order-random` maze-runner flag from CI as it's just annoying and doesn't add anything  

## Testing

Manually tested the changes on a separate branch using hardcoded values for the bugsnag-js branch and commit.

Note that the network breadcrumbs tests are still failing because of a bug in the request-tracker package, but this should be resolved with the next bugsnag-js release - we need to force-merge this to unblock CI in bugsnag-js