### PR TITLE
 Move to @bugsnag/cli for source map uploads

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,7 +20,7 @@ steps:
       queue: "macos-15"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      NODE_VERSION: "18.18"
+      NODE_VERSION: "20"
       JAVA_VERSION: "17"
     artifact_paths: build/output.apk
     commands:
@@ -34,7 +34,7 @@ steps:
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
       XCODE_VERSION: "16.2.0"
-      NODE_VERSION: "18.18"
+      NODE_VERSION: "20"
     artifact_paths: build/output.ipa
     commands:
       - bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,6 @@ steps:
     agents:
       queue: "macos-15"
     env:
-      XCODE_VERSION: "16.2.0"
     command: scripts/license_finder.sh
 
   - label:  ':android: Build expo APK'
@@ -20,7 +19,6 @@ steps:
       queue: "macos-15"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      NODE_VERSION: "18.18"
       JAVA_VERSION: "17"
     artifact_paths: build/output.apk
     commands:
@@ -33,8 +31,6 @@ steps:
       queue: "macos-15"
     env:
       EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
-      XCODE_VERSION: "16.2.0"
-      NODE_VERSION: "18.18"
     artifact_paths: build/output.ipa
     commands:
       - bundle install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Migrate from the `@bugsnag/source-map` tool over to `@bugsnag/cli` for the EAS sourcemap plugin [#252](https://github.com/bugsnag/bugsnag-expo/pull/252)
+
 ## [52.0.1] - 2025-02-20
 
 ### Changed

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -20,12 +20,12 @@
     "expo-secure-store": "~14.0.0",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
-    "react-native": "0.76.9"
+    "react-native": "0.76.7"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@bugsnag/cli": "^3.7.0",
     "@bugsnag/plugin-expo-eas-sourcemaps": "*",
+    "@bugsnag/cli": "^3.7.0",
     "bugsnag-expo-cli": "*"
   },
   "private": true

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "@bugsnag/expo": "*",
     "@react-native-community/netinfo": "11.4.1",
-    "expo": "^52.0.0",
+    "expo": "^52.0.49",
     "expo-application": "~6.0.1",
-    "expo-constants": "~17.0.3",
+    "expo-constants": "~17.0.8",
     "expo-crypto": "~14.0.1",
     "expo-device": "~7.0.1",
     "expo-file-system": "~18.0.4",
@@ -20,7 +20,13 @@
     "expo-secure-store": "~14.0.0",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
-    "react-native": "0.76.7"
+    "react-native": "0.76.9"
+  },
+  "resolutions": {
+    "react-native": "0.76.9"
+  },
+  "overrides": {
+    "react-native": "0.76.9"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -20,12 +20,12 @@
     "expo-secure-store": "~14.0.0",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
-    "react-native": "0.76.7"
+    "react-native": "0.76.9"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@bugsnag/plugin-expo-eas-sourcemaps": "*",
     "@bugsnag/cli": "^3.7.0",
+    "@bugsnag/plugin-expo-eas-sourcemaps": "*",
     "bugsnag-expo-cli": "*"
   },
   "private": true

--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@bugsnag/plugin-expo-eas-sourcemaps": "*",
-    "@bugsnag/source-maps": "^2.3.3",
+    "@bugsnag/cli": "^3.7.0",
     "bugsnag-expo-cli": "*"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -8,13 +8,16 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-standard": "^4.0.1",
-    "expo": "^52.0.0",
+    "expo": "^52.0.49",
     "jest": "^29.3.1",
     "jest-expo": "~52.0.2",
     "lerna": "^8.0.2",
     "react": "18.3.1",
-    "react-native": "0.76.7",
+    "react-native": "0.76.9",
     "verdaccio": "^5.10.2"
+  },
+  "overrides": {
+    "react-native": "0.76.9"
   },
   "scripts": {
     "test:unit": "jest",

--- a/packages/expo-cli/lib/configure-plugin.js
+++ b/packages/expo-cli/lib/configure-plugin.js
@@ -90,7 +90,7 @@ module.exports = async (projectRoot) => {
     if (addMonorepoConfig) {
       console.log(blue('> yarn workspaces detected, updating config'))
 
-      const sourceMaps = '@bugsnag/source-maps'
+      const sourceMaps = '@bugsnag/cli'
 
       if (withYarnClassic) {
         packageJson.workspaces = packageJson.workspaces || {}

--- a/packages/expo-cli/lib/install-plugin.js
+++ b/packages/expo-cli/lib/install-plugin.js
@@ -2,7 +2,7 @@ const { createForProject } = require('@expo/package-manager')
 const { resolvePackageName } = require('./utils')
 
 module.exports = (version, projectRoot, options) => {
-  const packages = [resolvePackageName('@bugsnag/plugin-expo-eas-sourcemaps', version), '@bugsnag/source-maps']
+  const packages = [resolvePackageName('@bugsnag/plugin-expo-eas-sourcemaps', version), '@bugsnag/cli']
 
   // Expo's package manager will reject with an error if the child process exits with a non-zero code
   // it also buffers the output and attaches it to any errors - https://github.com/expo/spawn-async/blob/main/src/spawnAsync.ts

--- a/packages/expo-cli/lib/test/install-plugin.test.js
+++ b/packages/expo-cli/lib/test/install-plugin.test.js
@@ -9,7 +9,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-js', async (projectRoot) => {
       const packageManager = {
         addDevAsync: async (packages) => {
-          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/cli'])
           return Promise.resolve()
         }
       }
@@ -32,7 +32,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-js', async (projectRoot) => {
       const packageManager = {
         addDevAsync: async (packages) => {
-          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/cli'])
           return Promise.resolve()
         }
       }
@@ -55,7 +55,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-js', async (projectRoot) => {
       const packageManager = {
         addDevAsync: async (packages) => {
-          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/cli'])
           return Promise.resolve()
         }
       }
@@ -79,7 +79,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-js', async (projectRoot) => {
       const packageManager = {
         addDevAsync: async (packages) => {
-          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/cli'])
           return Promise.resolve()
         }
       }
@@ -102,7 +102,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-js', async (projectRoot) => {
       const packageManager = {
         addDevAsync: async (packages) => {
-          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps@^48.0.0', '@bugsnag/source-maps'])
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps@^48.0.0', '@bugsnag/cli'])
           return Promise.resolve()
         }
       }
@@ -124,7 +124,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
     await withFixture('blank-js', async (projectRoot) => {
       const packageManager = {
         addDevAsync: async (packages) => {
-          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+          expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/cli'])
           return Promise.reject(new Error('floop'))
         }
       }
@@ -144,7 +144,7 @@ describe('expo-cli: upload-sourcemaps install plugin', () => {
   it('should add stderr/stdout output onto error if there is one', async () => {
     const packageManager = {
       addDevAsync: async (packages) => {
-        expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/source-maps'])
+        expect(packages).toEqual(['@bugsnag/plugin-expo-eas-sourcemaps', '@bugsnag/cli'])
         const error = new Error('floop')
         error.stdout = 'some data on stdout'
         error.stderr = 'some data on stderr'

--- a/packages/expo/hooks/lib/upload-source-maps.js
+++ b/packages/expo/hooks/lib/upload-source-maps.js
@@ -1,9 +1,8 @@
-const sourceMaps = require('@bugsnag/source-maps').reactNative
-const logger = require('@bugsnag/source-maps/dist/Logger').default
 const { promisify } = require('util')
 const { tmpdir } = require('os')
 const { sep, join } = require('path')
 const { mkdtemp, writeFile } = require('fs')
+const BugsnagCLI = require('@bugsnag/cli')
 
 const writeFileAsync = promisify(writeFile)
 
@@ -35,29 +34,29 @@ module.exports = async (
   const opts = { apiKey }
   if (endpoint) opts.endpoint = endpoint
 
-  logger.info('Uploading source maps to Bugsnag')
+  console.log('Uploading source map to Bugsnag...')
 
   // android
-  await sourceMaps.uploadOne({
-    ...opts,
-    appVersion: androidManifest.version,
-    codeBundleId: androidManifest.revisionId,
-    bundle: androidBundlePath,
-    sourceMap: androidSourceMapPath,
-    platform: 'android',
-    logger
-  })
+  await BugsnagCLI.Upload.ReactNative.Android(
+    {
+      apiKey: apiKey,
+      versionName: androidManifest.version,
+      codeBundleId: androidManifest.revisionId,
+      bundle: androidBundlePath,
+      sourceMap: androidSourceMapPath
+    }
+  )
 
   // ios
-  await sourceMaps.uploadOne({
-    ...opts,
-    appVersion: iosManifest.version,
-    codeBundleId: iosManifest.revisionId,
-    bundle: iosBundlePath,
-    sourceMap: iosSourceMapPath,
-    platform: 'ios',
-    logger
-  })
+  await BugsnagCLI.Upload.ReactNative.iOS(
+    {
+      apiKey: apiKey,
+      versionName: androidManifest.version,
+      codeBundleId: androidManifest.revisionId,
+      bundle: androidBundlePath,
+      sourceMap: androidSourceMapPath
+    }
+  )
 }
 
 const makeTmpDir = async () => promisify(mkdtemp)(`${tmpdir()}${sep}bugsnag-expo-`)

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -49,11 +49,11 @@
     "bugsnag-build-reporter": "^2.0.0"
   },
   "devDependencies": {
-    "expo-constants": "~17.0.3"
+    "expo-constants": "~17.0.8"
   },
   "peerDependencies": {
     "expo": "^52.0.0",
-    "expo-constants": "~17.0.3",
+    "expo-constants": "~17.0.8",
     "promise": "^8.3.0",
     "react": "*"
   }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -45,7 +45,7 @@
     "@bugsnag/plugin-react-native-global-error-handler": "^7.22.7",
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^7.22.7",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^7.22.7",
-    "@bugsnag/source-maps": "^2.3.3",
+    "@bugsnag/cli": "^3.7.0",
     "bugsnag-build-reporter": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -32,6 +32,7 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
+    "@bugsnag/cli": "^3.7.0",
     "@bugsnag/core": "^7.22.7",
     "@bugsnag/delivery-expo": "^52.0.0",
     "@bugsnag/plugin-browser-session": "^7.22.7",
@@ -45,7 +46,6 @@
     "@bugsnag/plugin-react-native-global-error-handler": "^7.22.7",
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^7.22.7",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^7.22.7",
-    "@bugsnag/cli": "^3.7.0",
     "bugsnag-build-reporter": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -32,7 +32,6 @@
   "author": "Bugsnag",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/cli": "^3.7.0",
     "@bugsnag/core": "^7.22.7",
     "@bugsnag/delivery-expo": "^52.0.0",
     "@bugsnag/plugin-browser-session": "^7.22.7",
@@ -46,6 +45,7 @@
     "@bugsnag/plugin-react-native-global-error-handler": "^7.22.7",
     "@bugsnag/plugin-react-native-orientation-breadcrumbs": "^7.22.7",
     "@bugsnag/plugin-react-native-unhandled-rejection": "^7.22.7",
+    "@bugsnag/cli": "^3.7.0",
     "bugsnag-build-reporter": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-expo-xcode.sh
+++ b/packages/plugin-expo-eas-sourcemaps/lib/bugsnag-expo-xcode.sh
@@ -41,10 +41,9 @@ PROJECT_ROOT=${PWD%\/ios}
 
 ARGS=(
     "--api-key" "$API_KEY"
-    "--app-version" "$APP_VERSION"
-    "--app-bundle-version" "$BUNDLE_VERSION"
+    "--version-name" "$APP_VERSION"
+    "--bundle-version" "$BUNDLE_VERSION"
     "--bundle" "$BUNDLE_FILE"
-    "--platform" "ios"
     "--source-map" "$SOURCE_MAP"
     "--project-root" "$PROJECT_ROOT"
     )
@@ -60,4 +59,4 @@ if [ ! -z "$ENDPOINT" ]; then
   ARGS+=("$ENDPOINT")
 fi
 
-../node_modules/.bin/bugsnag-source-maps upload-react-native "${ARGS[@]}"
+../node_modules/.bin/bugsnag-cli upload react-native-ios "${ARGS[@]}"

--- a/packages/plugin-expo-eas-sourcemaps/lib/eas-build-on-success.js
+++ b/packages/plugin-expo-eas-sourcemaps/lib/eas-build-on-success.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { access } = require('fs').promises
-const { reactNative } = require('@bugsnag/source-maps')
+const BugsnagCLI = require('@bugsnag/cli')
 const { exit } = require('process')
 const { getConfig } = require('@expo/config')
 
@@ -43,14 +43,13 @@ const uploadSourceMaps = async () => {
   }
 
   console.log('Uploading Android source map to Bugsnag...')
-  await reactNative.uploadOne({
-    apiKey,
-    bundle,
-    sourceMap,
-    platform: 'android',
-    appVersion: appConfig?.exp?.version,
-    appVersionCode: appConfig?.exp?.android?.versionCode?.toString()
-  }).then(() => {
+  await BugsnagCLI.Upload.ReactNative.Android(
+    {
+      apiKey: apiKey,
+      projectRoot: PROJECT_ROOT
+    }
+    , PROJECT_ROOT
+  ).then(() => {
     console.log(`Successfully uploaded the following files:\n${[bundle, sourceMap].join('\n')}`)
   }).catch(error => {
     console.error(`Error uploading source map: ${error}`)

--- a/packages/plugin-expo-eas-sourcemaps/package.json
+++ b/packages/plugin-expo-eas-sourcemaps/package.json
@@ -23,7 +23,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "@bugsnag/source-maps": "^2.3.3",
+    "@bugsnag/cli": "^3.7.0",
     "@expo/config": "~10.0.2"
   },
   "author": "Bugsnag",


### PR DESCRIPTION
## Goal

- Migrate from @bugsnag/source-maps to @bugsnag/cli for `eas` source map uploads.
- Fix build issues on CI for Expo v52

## Testing

Covered by CI