### PR TITLE
Plat 15815/expo secure store key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Migrate from the `@bugsnag/source-map` tool over to `@bugsnag/cli` for the EAS sourcemap plugin [#247](https://github.com/bugsnag/bugsnag-expo/pull/247)
 
+### Fixed
+
+- (plugin-expo-device) Use `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY` keychain accessibility for SecureStore so that Bugsnag works during background tasks [#256](https://github.com/bugsnag/bugsnag-expo/pull/256)
+
 ## [54.0.0] - 2025-09-15
 
 This release adds support for Expo 54

--- a/packages/expo/test/index.test.js
+++ b/packages/expo/test/index.test.js
@@ -90,7 +90,7 @@ jest.doMock('../../../node_modules/expo-device', () => ({
 jest.doMock('expo-secure-store', () => ({
   getItem: () => 'c0123456789abcdef0123456789',
   setItem: () => {},
-  ALWAYS_THIS_DEVICE_ONLY: 4
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
 }))
 
 const networkBreadcrumbsPlugin = {

--- a/packages/plugin-expo-device/device.js
+++ b/packages/plugin-expo-device/device.js
@@ -29,7 +29,7 @@ module.exports = {
     if (Platform.OS === 'android' || Platform.OS === 'ios') {
       const storeOptions = {
         requireAuthentication: false,
-        keychainAccessible: SecureStore.ALWAYS_THIS_DEVICE_ONLY
+        keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
       }
 
       deviceId = SecureStore.getItem(DEVICE_ID_KEY, storeOptions)

--- a/packages/plugin-expo-device/test/device.test.js
+++ b/packages/plugin-expo-device/test/device.test.js
@@ -38,7 +38,7 @@ describe('plugin: expo device', () => {
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
     jest.doMock('expo-secure-store', () => ({
       getItem: () => 'c0123456789abcdef0123456789',
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')
@@ -111,7 +111,7 @@ describe('plugin: expo device', () => {
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
     jest.doMock('expo-secure-store', () => ({
       getItem: () => 'c0123456789abcdef0123456789',
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')
@@ -176,7 +176,7 @@ describe('plugin: expo device', () => {
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
     jest.doMock('expo-secure-store', () => ({
       getItem: () => 'c0123456789abcdef0123456789',
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')
@@ -226,7 +226,7 @@ describe('plugin: expo device', () => {
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
     jest.doMock('expo-secure-store', () => ({
       getItem: () => 'c0123456789abcdef0123456789',
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')
@@ -298,7 +298,7 @@ describe('plugin: expo device', () => {
     jest.doMock('react-native/package.json', () => ({ version: REACT_NATIVE_VERSION }))
     jest.doMock('expo-secure-store', () => ({
       getItem: () => 'c0123456789abcdef0123456789',
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')
@@ -362,7 +362,7 @@ describe('plugin: expo device', () => {
     jest.doMock('expo-secure-store', () => ({
       getItem,
       setItem,
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')
@@ -421,7 +421,7 @@ describe('plugin: expo device', () => {
     jest.doMock('expo-secure-store', () => ({
       getItem,
       setItem,
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')
@@ -481,7 +481,7 @@ describe('plugin: expo device', () => {
     jest.doMock('expo-secure-store', () => ({
       getItem,
       setItem,
-      ALWAYS_THIS_DEVICE_ONLY: 4
+      AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 4
     }))
 
     const plugin = require('..')


### PR DESCRIPTION
Goal
<!-- Why is this change necessary? -->

Fix Bugsnag integration so it works correctly when the app runs background tasks on iOS by using the correct expo-secure-store keychain accessibility option.

Design
<!-- Why was this approach used? -->

The previous configuration used ALWAYS_THIS_DEVICE_ONLY, which caused keychain access errors when the app was in the background. Switching to [AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) allows access after the device is unlocked, including during background tasks, and is the recommended option for this use case.

Changeset
<!-- What changed? -->

Updated [plugin-expo-device](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use [AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for SecureStore keychain accessibility.
Updated related mocks and tests to match the new keychain accessibility constant.

Testing
<!-- How was it tested? What manual and automated tests were run/added? -->
All affected tests were updated and run to verify correct behavior.
Manual testing confirmed that Bugsnag no longer throws keychain access errors during background tasks on iOS