### PR TITLE
Use node v22 and yarn for unit tests in CI (v54)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18']
+        node-version: ['22']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,8 +19,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - run: npm install --no-audit --no-package-lock
+    - run: yarn install --no-lockfile
 
-    - run: npm run test:unit
+    - run: yarn run test:unit
 
-    - run: npm run test:lint
+    - run: yarn run test:lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ This repository includes an example app for each supported version in the `/exam
 ## System requirements
 
 In order to develop on the project you’ll need to be on Mac/Linux٭. You’ll need:
-- [node](https://nodejs.org) `v8+` (which includes [npm](https://www.npmjs.com/get-npm) 5+)
+- [node](https://nodejs.org) `v18+`
+- [yarn 1](https://classic.yarnpkg.com/) (Classic)
 - [git](https://git-scm.com/)
 
 If you want to run the end-to-end tests locally you'll need [Docker](https://www.docker.com/products/docker-desktop) (including Docker Compose), and the [AWS CLI](https://aws.amazon.com/cli/). Note that you'll also need some BrowserStack and AWS credentials which are only available to Bugsnag employees.

--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@ git clone git@github.com:bugsnag/bugsnag-expo.git
 cd bugsnag-expo
 
 # Install top-level dependencies
-npm i
+yarn install
 
 # Run the unit tests
-npm run test:unit
+yarn run test:unit
 
 # Run tests for a specific package
-npm run test:unit -- --testPathPattern="packages/expo"
+yarn run test:unit -- --testPathPattern="packages/expo"
 
 # Generate a code coverage report
-npm run test:unit -- --coverage
+yarn run test:unit -- --coverage
 
 # Run the linter
-npm run test:lint
+yarn run test:lint
 ```
 
 See [contributing](CONTRIBUTING.md) for more information.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:lint": "eslint --report-unused-disable-directives --max-warnings=0 .",
     "local-npm:start": "verdaccio --config ./verdaccio-config.yml",
     "local-npm:publish-all": "lerna publish --yes --force-publish --exact --no-push --no-git-reset --no-git-tag-version --registry 'http://localhost:4873'",
-    "expo-install:fix": "npx expo install --fix && npm exec --workspaces -- npx expo install --fix"
+    "expo-install:fix": "npx expo install --fix -- -W && npm exec --workspaces -- npx expo install --fix"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Goal

Updates the unit test CI workflow to use node 22 and yarn for consistency.

This is a backport of changes already applied in v55. 

The github status check for the unit test workflow seems to be node version-specific, and has been updated to node 22 - backporting means the status check works for PRs into v54 branches as well

## Testing

Covered by CI