### PR TITLE
update release documentation to use NPM_Token instead of 2FA 

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -10,6 +10,7 @@ error_missing_field () {
 # Ensure all required variables are set before doing any work
 if [[ -z ${GITHUB_USER:-} ]]; then error_missing_field "GITHUB_USER"; fi
 if [[ -z ${GITHUB_ACCESS_TOKEN:-} ]]; then error_missing_field "GITHUB_ACCESS_TOKEN"; fi
+if [[ -z ${NPM_TOKEN:-} ]]; then error_missing_field "NPM_TOKEN"; fi
 if [[ -z ${RELEASE_BRANCH:-} ]]; then error_missing_field "RELEASE_BRANCH"; fi
 if [[ -z ${VERSION:-} ]]; then error_missing_field "VERSION"; fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       GITHUB_USER:
       GITHUB_ACCESS_TOKEN:
+      NPM_TOKEN:
       RELEASE_BRANCH:
       RETRY_PUBLISH:
       VERSION:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -54,6 +54,7 @@ You are now ready to make the release. Releases are done using Docker. You do no
 - Ensure you are logged in to npm and that you have access to publish to the following on npm
   - any packages in the `@bugsnag` namespace
   - the `bugsnag-expo-cli` package
+- Generate a [granular access token](https://www.npmjs.com/settings/{username}/tokens/granular-access-tokens/new) on  NPM to bypass 2FA and store it somewhere secure
 - Ensure your `.gitconfig` file in your home directory is configured to contain your name and email address
 - Generate a [personal access token](https://github.com/settings/tokens/new) on GitHub and store it somewhere secure
 
@@ -70,12 +71,13 @@ You may want to consider shipping a [prerelease](#prerelease) to aid testing the
 ```sh
 GITHUB_USER=<your github username> \
 GITHUB_ACCESS_TOKEN=<generate a personal access token> \
+NPM_TOKEN=<generate a personal granular access token> \
 RELEASE_BRANCH=<the branch to publish a new release from> \
 VERSION=[major | minor | patch] \
   docker-compose run release
 ```
 
-This process is interactive and will require you to confirm that you want to publish the changed packages. It will also prompt for 2FA.
+This process is interactive and will require you to confirm that you want to publish the changed packages.
 
 **Note**: if a prerelease was made, to graduate it into a normal release you will need to use `patch` as the version.
 
@@ -111,6 +113,7 @@ For example:
 ```
 GITHUB_USER=<your github username> \
 GITHUB_ACCESS_TOKEN=<generate a personal access token> \
+NPM_TOKEN=<generate a personal granular access token> \
 RELEASE_BRANCH=<the branch to publish a new release from> \
 VERSION=preminor \
   docker-compose run release

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -54,7 +54,7 @@ You are now ready to make the release. Releases are done using Docker. You do no
 - Ensure you are logged in to npm and that you have access to publish to the following on npm
   - any packages in the `@bugsnag` namespace
   - the `bugsnag-expo-cli` package
-- Generate a [granular access token](https://www.npmjs.com/settings/{username}/tokens/granular-access-tokens/new) on  NPM to bypass 2FA and store it somewhere secure
+- Generate a [granular access token](https://www.npmjs.com/settings/{username}/tokens/granular-access-tokens/new) on NPM as a fallback mechanism when 2FA is not feasible and store it somewhere secure
 - Ensure your `.gitconfig` file in your home directory is configured to contain your name and email address
 - Generate a [personal access token](https://github.com/settings/tokens/new) on GitHub and store it somewhere secure
 


### PR DESCRIPTION
## Goal

update release documentation to use NPM_Token instead of 2FA for publishing npm package

## Design

NA

## Changeset

docker-compose and release documentation update

## Testing

No testing required