### PR TITLE
Release/v57.0.0

### DIFF
--- a/features/fixtures/test-app/package.json
+++ b/features/fixtures/test-app/package.json
@@ -20,7 +20,7 @@
     "expo-secure-store": "~57.0.1",
     "expo-status-bar": "~57.0.1",
     "react": "19.2.3",
-    "react-native": "0.86.0"
+    "react-native": "0.86.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@react-native/jest-preset": "^0.86.0",
+    "@react-native/jest-preset": "^0.86.2",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.20.1",
@@ -14,8 +14,11 @@
     "jest-expo": "^57.0.0",
     "lerna": "^8.0.2",
     "react": "19.2.3",
-    "react-native": "0.86.0",
+    "react-native": "0.86.2",
     "verdaccio": "^5.10.2"
+  },
+  "engines": {
+    "node": "^20.17.0 || >=22.9.0"
   },
   "scripts": {
     "test:unit": "jest",


### PR DESCRIPTION
## Goal

bump react-native to 0.86.2 to resolve @react-native/jest-preset peer dependency conflict with jest-expo@57.0.4